### PR TITLE
Uses Log.* for *(...) where *'s are equal

### DIFF
--- a/timber/src/main/java/timber/log/Timber.java
+++ b/timber/src/main/java/timber/log/Timber.java
@@ -41,7 +41,7 @@ public interface Timber {
     }
 
     @Override public void d(Throwable t, String message, Object... args) {
-      Log.e(className(), String.format(message, args), t);
+      Log.d(className(), String.format(message, args), t);
     }
 
     @Override public void i(String message, Object... args) {
@@ -49,7 +49,7 @@ public interface Timber {
     }
 
     @Override public void i(Throwable t, String message, Object... args) {
-      Log.e(className(), String.format(message, args), t);
+      Log.i(className(), String.format(message, args), t);
     }
 
     @Override public void w(String message, Object... args) {
@@ -57,7 +57,7 @@ public interface Timber {
     }
 
     @Override public void w(Throwable t, String message, Object... args) {
-      Log.e(className(), String.format(message, args), t);
+      Log.w(className(), String.format(message, args), t);
     }
 
     @Override public void e(String message, Object... args) {


### PR DESCRIPTION
I don't know if you meant to do so, but all of the log messages that took a `Throwable` used `Log.e(...)` regardless of which `Timber` method was called, which means they were identical. If you did, you can disregard this (though also curious why you do it that way). Otherwise, here's a very simple patch that corrects that.
