### PR TITLE
Improve performance of stacktrace generation

### DIFF
--- a/timber/src/main/java/timber/log/Timber.java
+++ b/timber/src/main/java/timber/log/Timber.java
@@ -37,7 +37,7 @@ public interface Timber {
         return tag;
       }
 
-      tag = Thread.currentThread().getStackTrace()[4].getClassName();
+      tag = new Throwable().getStackTrace()[3].getClassName();
       Matcher m = anonymousClass.matcher(tag);
       if (m != null && m.find()) {
         tag = m.replaceAll("");


### PR DESCRIPTION
Generating a new Throwable() is a quicker way of getting the current
stacktrace than examining by thread. Some benchmarks are posted on this
StackOverflow answer: http://stackoverflow.com/a/10625065/14302
