### PR TITLE
Implement Lint check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
   <modules>
     <module>timber</module>
     <module>timber-sample</module>
+    <module>timber-lint</module>
   </modules>
 
   <properties>
@@ -34,6 +35,7 @@
     <junit.version>4.10</junit.version>
     <robolectric.version>2.2</robolectric.version>
     <fest.version>2.0M10</fest.version>
+    <lint.version>22.4.0</lint.version>
   </properties>
 
   <scm>
@@ -81,6 +83,11 @@
         <groupId>org.easytesting</groupId>
         <artifactId>fest-assert-core</artifactId>
         <version>${fest.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.android.tools.lint</groupId>
+        <artifactId>lint</artifactId>
+        <version>${lint.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/timber-lint/pom.xml
+++ b/timber-lint/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.jakewharton.timber</groupId>
+    <artifactId>timber-parent</artifactId>
+    <version>2.1.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>timber-lint</artifactId>
+  <name>Timber Lint</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.android.tools.lint</groupId>
+      <artifactId>lint</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>src/main/resources/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/timber-lint/src/main/java/timber/lint/CallToLogNotTimberDetector.java
+++ b/timber-lint/src/main/java/timber/lint/CallToLogNotTimberDetector.java
@@ -1,0 +1,41 @@
+package timber.lint;
+
+import com.android.tools.lint.detector.api.Category;
+import com.android.tools.lint.detector.api.Detector;
+import com.android.tools.lint.detector.api.Implementation;
+import com.android.tools.lint.detector.api.Issue;
+import com.android.tools.lint.detector.api.JavaContext;
+import com.android.tools.lint.detector.api.Scope;
+import com.android.tools.lint.detector.api.Severity;
+
+import java.util.Arrays;
+import java.util.List;
+
+import lombok.ast.AstVisitor;
+import lombok.ast.MethodInvocation;
+
+public class CallToLogNotTimberDetector extends Detector implements Detector.JavaScanner {
+
+  @Override
+  public List<String> getApplicableMethodNames() {
+    return Arrays.asList("d", "i", "w", "e");
+  }
+
+  @Override
+  public void visitMethod(JavaContext context, AstVisitor visitor, MethodInvocation node) {
+    if (node.toString().startsWith("Log.")) {
+      context.report(ISSUE, node, context.getLocation(node),
+          "Using 'Log' instead of 'Timber'", null);
+    }
+  }
+
+  public static final Issue ISSUE = Issue.create(
+      "LogNotTimber",
+      "Logging call to Log instead of Timber",
+      "This check looks through all the logging calls for instances where the Android Log " +
+          "class was used instead of Timber.",
+      "Since Timber is included in the project, it is likely that calls to Log should " +
+          "instead be going to Timber.",
+      Category.CORRECTNESS, 5, Severity.WARNING,
+      new Implementation(CallToLogNotTimberDetector.class, Scope.JAVA_FILE_SCOPE));
+}

--- a/timber-lint/src/main/java/timber/lint/IssueRegistry.java
+++ b/timber-lint/src/main/java/timber/lint/IssueRegistry.java
@@ -1,0 +1,14 @@
+package timber.lint;
+
+import com.android.tools.lint.detector.api.Issue;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class IssueRegistry extends com.android.tools.lint.client.api.IssueRegistry {
+
+  @Override
+  public List<Issue> getIssues() {
+    return Arrays.asList(CallToLogNotTimberDetector.ISSUE);
+  }
+}

--- a/timber-lint/src/main/resources/META-INF/MANIFEST.MF
+++ b/timber-lint/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+Manifest-Version: 1.0
+Lint-Registry: timber.lint.IssueRegistry


### PR DESCRIPTION
Will scan Java files for instances where Log.x is used rather than Timber.x
and presents them as warnings.

There is a way to include the lint.jar inside an AAR which will make the build system automatically recognize it, but the process for this is still in development. Here is a thread details ing: https://groups.google.com/forum/#!msg/adt-dev/seWAK5r1fjI/pDF6uWs9ipoJ

This PR does not include any auto-detection. Rather, users will still need to move the generate lint jar into the appropriate directory on their system.
