### PR TITLE
Changed DebugTree.createTag() visibility to protected

### DIFF
--- a/timber/src/main/java/timber/log/Timber.java
+++ b/timber/src/main/java/timber/log/Timber.java
@@ -160,7 +160,7 @@ public final class Timber {
     private static final Pattern ANONYMOUS_CLASS = Pattern.compile("\\$\\d+$");
     private String nextTag;
 
-    private String createTag() {
+    protected String createTag() {
       String tag = nextTag;
       if (tag != null) {
         nextTag = null;


### PR DESCRIPTION
This method should be usable from derived classes. e.g. for adjusting the
output based on the tag.
