### PR TITLE
If no varargs are supplied in DebugTree, treat it as a request to log th...

### DIFF
--- a/timber/src/main/java/timber/log/Timber.java
+++ b/timber/src/main/java/timber/log/Timber.java
@@ -203,8 +203,8 @@ public final class Timber {
       return tag.substring(tag.lastIndexOf('.') + 1);
     }
 
-    /** If no varargs are supplied, treat it as a request to log the string without formatting */
     private static String formatString(String message, Object... args) {
+      // If no varargs are supplied, treat it as a request to log the string without formatting
       return args.length == 0 ? message : String.format(message, args);
     }
 


### PR DESCRIPTION
...e string without formatting

Occasionally we need to log long URLs, which may contain all manner of strange characters. The default implementation was at times tripping over these characters, thinking they were string formatting parameters, and would throw an exception. If no varargs are passed to a logging call, it should be safe to assume that the user wishes to log the string without change, and DebugTree should bypass String.format(); Otherwise there is no method for logging a simple string without passing it through String's formatter (aside from the delightfully hacky d("%s", string) ).
