### PR TITLE
Use stringFormat on DebugTree.d(String message, Object... args) too

### DIFF
--- a/timber/src/main/java/timber/log/Timber.java
+++ b/timber/src/main/java/timber/log/Timber.java
@@ -217,7 +217,7 @@ public final class Timber {
     }
 
     @Override public void d(String message, Object... args) {
-      Log.d(createTag(), String.format(message, args));
+      Log.d(createTag(), formatString(message, args));
     }
 
     @Override public void d(Throwable t, String message, Object... args) {


### PR DESCRIPTION
https://github.com/JakeWharton/timber/pull/16 Missed to change DebugTree.d(String message, Object... args) to use stringFormat too, causing crashes when logging URL with formatting characters.
