### PR TITLE
Added ErrorWarningTree similar to Debug tree for production builds.

### DIFF
--- a/timber/src/main/java/timber/log/Timber.java
+++ b/timber/src/main/java/timber/log/Timber.java
@@ -252,7 +252,7 @@ public final class Timber {
       NEXT_TAG.set(tag);
     }
   }
-  
+
   /** A {@link Tree} for production builds. Will print info, warning and error logs.
    *  Automatically infers the tag from the calling class.*/
   public static class ErrorWarningTree implements TaggedTree {
@@ -280,19 +280,19 @@ public final class Timber {
     }
 
     @Override public void v(String message, Object... args) {
-      
+
     }
 
     @Override public void v(Throwable t, String message, Object... args) {
-      
+
     }
 
     @Override public void d(String message, Object... args) {
-      
+
     }
 
     @Override public void d(Throwable t, String message, Object... args) {
-      
+
     }
 
     @Override public void i(String message, Object... args) {


### PR DESCRIPTION
This will help users to directly user Tinder jar for production builds too. Currently users have to implement Hollow tree for production build even if they are not using any crash reporting tool.

Now with my change user can easily add below code and are good to go without any extra implementation in Application class.

```
@Override
public void onCreate() {
    super.onCreate();
    setLogging();
}

private void setLogging() {
    if (BuildConfig.DEBUG) {
        Timber.plant(new DebugTree());
    } else {
        Timber.plant(new ErrorWarningTree());
    }
}
```
