### PR TITLE
Don't swallow log messages that are null but have a throwable

### DIFF
--- a/timber/src/main/java/timber/log/Timber.java
+++ b/timber/src/main/java/timber/log/Timber.java
@@ -280,7 +280,7 @@ public final class Timber {
           return;
         }
       } else if (t != null) {
-          message += "\n" + Log.getStackTraceString(t);
+        message += "\n" + Log.getStackTraceString(t);
       }
 
       String tag = createTag();

--- a/timber/src/test/java/timber/log/TimberTest.java
+++ b/timber/src/test/java/timber/log/TimberTest.java
@@ -119,34 +119,20 @@ public class TimberTest {
 
   @Test
   public void testLogNullMessageWithThrowable() throws Exception {
-      Timber.plant(new Timber.DebugTree());
-      final NullPointerException datThrowable = new NullPointerException();
-      final CountDownLatch latch = new CountDownLatch(1);
-      new Thread() {
-          @Override public void run() {
-              Timber.e(datThrowable, null);
-              latch.countDown();
-          }
-      }.run();
-      latch.await();
+    Timber.plant(new Timber.DebugTree());
+    final NullPointerException datThrowable = new NullPointerException();
+    Timber.e(datThrowable, null);
 
-      assertExceptionLogged("", "java.lang.NullPointerException");
+    assertExceptionLogged("", "java.lang.NullPointerException");
   }
 
   @Test
   public void testLogNullMessageWithoutThrowable() throws Exception {
-      Timber.plant(new Timber.DebugTree());
-      final CountDownLatch latch = new CountDownLatch(1);
-      new Thread() {
-          @Override public void run() {
-              Timber.d(null);
-              latch.countDown();
-          }
-      }.run();
-      latch.await();
+    Timber.plant(new Timber.DebugTree());
+    Timber.d(null);
 
-      List<LogItem> logs = ShadowLog.getLogs();
-      assertThat(logs).hasSize(0);
+    List<LogItem> logs = ShadowLog.getLogs();
+    assertThat(logs).hasSize(0);
   }
 
     private static void assertExceptionLogged(String message, String exceptionClassname) {


### PR DESCRIPTION
In some places, I log using:

```
Timber.e(throwable, throwable.getMessage())
```

If the throwable in question was created with a null or empty message, the log message would disappear into the ether. This pull request causes the stack trace to be logged with an empty message instead.
