### PR TITLE
It's now possible to adjust the tag generation if the Timber is wrapped into another logger framework

### DIFF
--- a/timber/src/main/java/timber/log/Timber.java
+++ b/timber/src/main/java/timber/log/Timber.java
@@ -237,7 +237,12 @@ public final class Timber {
     private static final Pattern ANONYMOUS_CLASS = Pattern.compile("\\$\\d+$");
     private static final ThreadLocal<String> NEXT_TAG = new ThreadLocal<String>();
 
-    private static String createTag() {
+    static String formatString(String message, Object... args) {
+      // If no varargs are supplied, treat it as a request to log the string without formatting.
+      return args.length == 0 ? message : String.format(message, args);
+    }
+
+    private String createTag() {
       String tag = NEXT_TAG.get();
       if (tag != null) {
         NEXT_TAG.remove();
@@ -245,11 +250,11 @@ public final class Timber {
       }
 
       StackTraceElement[] stackTrace = new Throwable().getStackTrace();
-      if (stackTrace.length < 6) {
+      if (getCallingLineStackTraceIndex() >= stackTrace.length) {
         throw new IllegalStateException(
             "Synthetic stacktrace didn't have enough elements: are you using proguard?");
       }
-      tag = stackTrace[5].getClassName();
+      tag = stackTrace[getCallingLineStackTraceIndex()].getClassName();
       Matcher m = ANONYMOUS_CLASS.matcher(tag);
       if (m.find()) {
         tag = m.replaceAll("");
@@ -257,9 +262,13 @@ public final class Timber {
       return tag.substring(tag.lastIndexOf('.') + 1);
     }
 
-    static String formatString(String message, Object... args) {
-      // If no varargs are supplied, treat it as a request to log the string without formatting.
-      return args.length == 0 ? message : String.format(message, args);
+    /**
+     * @return the index that should be used to have the line of the class that uses the logger
+     * when creating tag for logging; override it if you want to wrap Timber with your own
+     * framework to have the correct tag
+     */
+    protected int getCallingLineStackTraceIndex() {
+      return 5;
     }
 
     @Override public void v(String message, Object... args) {


### PR DESCRIPTION
Let's image that we don't want to use Timber directly in our applications, but we have a custom interface for logging that use a Timber delegate as its implementation. Let's call that interface "Logger". So in the debug log we want to print the line when Logger.d() was called, not Timber.d() (we already know this line, it's always inside our "Logger").
The aim of this change is to make possible to customize which line from the calling stack trace should be printed by the DebugTree.