### PR TITLE
Provide a callback for logging a message on a DebugTree.

### DIFF
--- a/timber/src/main/java/timber/log/Timber.java
+++ b/timber/src/main/java/timber/log/Timber.java
@@ -287,43 +287,43 @@ public final class Timber {
       return args.length == 0 ? message : String.format(message, args);
     }
 
-    @Override public void v(String message, Object... args) {
+    @Override public final void v(String message, Object... args) {
       throwShade(Log.VERBOSE, maybeFormat(message, args), null);
     }
 
-    @Override public void v(Throwable t, String message, Object... args) {
+    @Override public final void v(Throwable t, String message, Object... args) {
       throwShade(Log.VERBOSE, maybeFormat(message, args), t);
     }
 
-    @Override public void d(String message, Object... args) {
+    @Override public final void d(String message, Object... args) {
       throwShade(Log.DEBUG, maybeFormat(message, args), null);
     }
 
-    @Override public void d(Throwable t, String message, Object... args) {
+    @Override public final void d(Throwable t, String message, Object... args) {
       throwShade(Log.DEBUG, maybeFormat(message, args), t);
     }
 
-    @Override public void i(String message, Object... args) {
+    @Override public final void i(String message, Object... args) {
       throwShade(Log.INFO, maybeFormat(message, args), null);
     }
 
-    @Override public void i(Throwable t, String message, Object... args) {
+    @Override public final void i(Throwable t, String message, Object... args) {
       throwShade(Log.INFO, maybeFormat(message, args), t);
     }
 
-    @Override public void w(String message, Object... args) {
+    @Override public final void w(String message, Object... args) {
       throwShade(Log.WARN, maybeFormat(message, args), null);
     }
 
-    @Override public void w(Throwable t, String message, Object... args) {
+    @Override public final void w(Throwable t, String message, Object... args) {
       throwShade(Log.WARN, maybeFormat(message, args), t);
     }
 
-    @Override public void e(String message, Object... args) {
+    @Override public final void e(String message, Object... args) {
       throwShade(Log.ERROR, maybeFormat(message, args), null);
     }
 
-    @Override public void e(Throwable t, String message, Object... args) {
+    @Override public final void e(Throwable t, String message, Object... args) {
       throwShade(Log.ERROR, maybeFormat(message, args), t);
     }
 
@@ -338,7 +338,11 @@ public final class Timber {
       }
 
       String tag = createTag();
+      logMessage(priority, tag, message);
+    }
 
+    /** Log a message! */
+    protected void logMessage(int priority, String tag, String message) {
       if (message.length() < MAX_LOG_LENGTH) {
         Log.println(priority, tag, message);
         return;

--- a/timber/src/test/java/timber/log/TimberTest.java
+++ b/timber/src/test/java/timber/log/TimberTest.java
@@ -1,6 +1,7 @@
 package timber.log;
 
 import android.util.Log;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -201,6 +202,38 @@ public class TimberTest {
 
     List<LogItem> logs = ShadowLog.getLogs();
     assertThat(logs).hasSize(0);
+  }
+
+  @Test public void logMessageCallback() {
+    final List<String> logs = new ArrayList<String>();
+    Timber.plant(new Timber.DebugTree() {
+      @Override protected void logMessage(int priority, String tag, String message) {
+        logs.add(priority + " " + tag + " " + message);
+      }
+    });
+
+    Timber.v("Verbose");
+    Timber.tag("Custom").v("Verbose");
+    Timber.d("Debug");
+    Timber.tag("Custom").d("Debug");
+    Timber.i("Info");
+    Timber.tag("Custom").i("Info");
+    Timber.w("Warn");
+    Timber.tag("Custom").w("Warn");
+    Timber.e("Error");
+    Timber.tag("Custom").e("Error");
+
+    assertThat(logs).containsExactly( //
+        "2 TimberTest Verbose", //
+        "2 Custom Verbose", //
+        "3 TimberTest Debug", //
+        "3 Custom Debug", //
+        "4 TimberTest Info", //
+        "4 Custom Info", //
+        "5 TimberTest Warn", //
+        "5 Custom Warn", //
+        "6 TimberTest Error", //
+        "6 Custom Error");
   }
 
   private static void assertExceptionLogged(String message, String exceptionClassname) {


### PR DESCRIPTION
This allows planting the tree for the tag behavior but redirecting the logs elsewhere. This also forbids extending the actual logging methods on this tree.