### PR TITLE
finger crossed tree

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <robolectric.version>2.2</robolectric.version>
     <fest.version>2.0M10</fest.version>
     <lint.version>24.1.2</lint.version>
+    <mockito.version>1.10.19</mockito.version>
   </properties>
 
   <scm>
@@ -88,6 +89,11 @@
         <groupId>com.android.tools.lint</groupId>
         <artifactId>lint</artifactId>
         <version>${lint.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/timber/pom.xml
+++ b/timber/pom.xml
@@ -28,6 +28,11 @@
       <artifactId>fest-assert-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>com.google.android</groupId>

--- a/timber/src/main/java/timber/log/FingerCrossedTree.java
+++ b/timber/src/main/java/timber/log/FingerCrossedTree.java
@@ -87,6 +87,9 @@ public class FingerCrossedTree implements Tree {
                     tree.e(t, message, args);
                 }
                 break;
+            default:
+                assert false : "Log level not managed";
+                break;
         }
     }
 

--- a/timber/src/main/java/timber/log/FingerCrossedTree.java
+++ b/timber/src/main/java/timber/log/FingerCrossedTree.java
@@ -1,0 +1,156 @@
+package timber.log;
+
+import timber.log.Timber.Tree;
+
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class FingerCrossedTree implements Tree {
+
+    private final Tree tree;
+    private final LogLevel actionLevel;
+    private final Queue<LogElement> buffer = new LinkedList<LogElement>();
+
+    public enum LogLevel {
+        VERBOSE(0), DEBUG(1), INFO(2), WARNING(3), ERROR(4);
+
+        private final int level;
+
+        LogLevel(int level) {
+            this.level = level;
+        }
+    }
+
+    public FingerCrossedTree(Tree tree, LogLevel actionLevel) {
+        this.tree = tree;
+        this.actionLevel = actionLevel;
+    }
+
+    private void maybeLog(Throwable t, String message, Object[] args, LogLevel threshold) {
+        if (thresholdReached(threshold)) {
+            dequeueMessages();
+            logMessage(t, message, args, threshold);
+        } else {
+            saveLog(t, message, args, threshold);
+        }
+    }
+
+    private void dequeueMessages() {
+        LogElement el;
+        while ((el = buffer.poll()) != null) {
+            logMessage(el.t, el.message, el.args, el.logLevel);
+        }
+    }
+
+    private boolean thresholdReached(LogLevel threshold) {
+        return actionLevel.level <= threshold.level;
+    }
+
+    private void saveLog(Throwable t, String message, Object[] args, LogLevel logLevel) {
+        buffer.offer(new LogElement(t, message, args, logLevel));
+    }
+
+    private void logMessage(Throwable t, String message, Object[] args, LogLevel logLevel) {
+        switch (logLevel) {
+            case VERBOSE:
+                if (t == null) {
+                    tree.v(message, args);
+                } else {
+                    tree.v(t, message, args);
+                }
+                break;
+            case DEBUG:
+                if (t == null) {
+                    tree.d(message, args);
+                } else {
+                    tree.d(t, message, args);
+                }
+                break;
+            case INFO:
+                if (t == null) {
+                    tree.i(message, args);
+                } else {
+                    tree.i(t, message, args);
+                }
+                break;
+            case WARNING:
+                if (t == null) {
+                    tree.w(message, args);
+                } else {
+                    tree.w(t, message, args);
+                }
+                break;
+            case ERROR:
+                if (t == null) {
+                    tree.e(message, args);
+                } else {
+                    tree.e(t, message, args);
+                }
+                break;
+        }
+    }
+
+    @Override
+    public void v(String message, Object... args) {
+        maybeLog(null, message, args, LogLevel.VERBOSE);
+    }
+
+    @Override
+    public void v(Throwable t, String message, Object... args) {
+        maybeLog(t, message, args, LogLevel.VERBOSE);
+    }
+
+    @Override
+    public void d(String message, Object... args) {
+        maybeLog(null, message, args, LogLevel.DEBUG);
+    }
+
+    @Override
+    public void d(Throwable t, String message, Object... args) {
+        maybeLog(t, message, args, LogLevel.DEBUG);
+    }
+
+    @Override
+    public void i(String message, Object... args) {
+        maybeLog(null, message, args, LogLevel.INFO);
+    }
+
+    @Override
+    public void i(Throwable t, String message, Object... args) {
+        maybeLog(t, message, args, LogLevel.INFO);
+    }
+
+    @Override
+    public void w(String message, Object... args) {
+        maybeLog(null, message, args, LogLevel.WARNING);
+    }
+
+    @Override
+    public void w(Throwable t, String message, Object... args) {
+        maybeLog(t, message, args, LogLevel.WARNING);
+    }
+
+    @Override
+    public void e(String message, Object... args) {
+        maybeLog(null, message, args, LogLevel.ERROR);
+    }
+
+    @Override
+    public void e(Throwable t, String message, Object... args) {
+        maybeLog(t, message, args, LogLevel.ERROR);
+    }
+
+    private static class LogElement {
+        public final Throwable t;
+        public final String message;
+        public final Object[] args;
+        public final LogLevel logLevel;
+
+        private LogElement(Throwable t, String message, Object[] args, LogLevel logLevel) {
+            this.t = t;
+            this.message = message;
+            this.args = args;
+            this.logLevel = logLevel;
+        }
+    }
+}

--- a/timber/src/test/java/timber/log/FingerCrossedTreeTest.java
+++ b/timber/src/test/java/timber/log/FingerCrossedTreeTest.java
@@ -1,0 +1,80 @@
+package timber.log;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FingerCrossedTreeTest {
+
+    @Mock Timber.Tree tree;
+    private FingerCrossedTree fingerCrossedTree;
+    private Object obj;
+    private Throwable t;
+
+    @Before
+    public void setUp() throws Exception {
+        fingerCrossedTree = new FingerCrossedTree(tree, FingerCrossedTree.LogLevel.WARNING);
+        obj = new Object();
+        t = new Throwable();
+    }
+
+    @Test
+    public void actionLevelReached() throws Exception {
+        fingerCrossedTree.w("warning", obj);
+        fingerCrossedTree.w(t, "warning", obj);
+        fingerCrossedTree.e("error", obj);
+        fingerCrossedTree.e(t, "error", obj);
+        verify(tree).w("warning", obj);
+        verify(tree).w(t, "warning", obj);
+        verify(tree).e("error", obj);
+        verify(tree).e(t, "error", obj);
+    }
+
+    @Test
+    public void actionLevelNotReached() throws Exception {
+        fingerCrossedTree.v("verbose", obj);
+        fingerCrossedTree.v(t, "verbose", obj);
+        fingerCrossedTree.i("info", obj);
+        fingerCrossedTree.i(t, "info", obj);
+        fingerCrossedTree.d("debug", obj);
+        fingerCrossedTree.d(t, "debug", obj);
+        verify(tree, never()).v("verbose", obj);
+        verify(tree, never()).v(t, "verbose", obj);
+        verify(tree, never()).i("info", obj);
+        verify(tree, never()).i(t, "info", obj);
+        verify(tree, never()).d("debug", obj);
+        verify(tree, never()).d(t, "debug", obj);
+    }
+
+    @Test
+    public void passPreviousLogs() throws Exception {
+        InOrder inOrder = inOrder(tree);
+
+        fingerCrossedTree.v("verbose", obj);
+        fingerCrossedTree.i(t, "info", obj);
+        fingerCrossedTree.e("error", obj);
+        inOrder.verify(tree).v("verbose", obj);
+        inOrder.verify(tree).i(t, "info", obj);
+        inOrder.verify(tree).e("error", obj);
+    }
+
+    @Test
+    public void passPreviousLogsOnce() throws Exception {
+        fingerCrossedTree.v("verbose", obj);
+        fingerCrossedTree.i(t, "info", obj);
+        fingerCrossedTree.e("error", obj);
+
+        reset(tree);
+
+        fingerCrossedTree.e("anotherError", obj);
+        verify(tree, never()).v("verbose", obj);
+        verify(tree, never()).i(t, "info", obj);
+        verify(tree, never()).e("error", obj);
+    }
+}


### PR DESCRIPTION
Hello,

this PR adds a finger crossed strategy tree.
It's inspired by [Monolog's finger crossed handler](https://github.com/Seldaek/monolog#wrappers--special-handlers).

In short: it will buffer the logs until something over the threshold happens, when that happens the previous logs are logged too, so that in case you have more info on what happens and it's easier to fix an eventual bug.

The only thing I'm not happy about is that the current implementation will keep ALL the messages, I would rather use something like [CircularFifoQueue](http://commons.apache.org/proper/commons-collections/javadocs/api-release/org/apache/commons/collections4/queue/CircularFifoQueue.html) but I wasn't sure if it would've been ok with you to add that in the project.