### PR TITLE
Extracted tagging functionality from DebugTree to AbstractTaggedTree

### DIFF
--- a/timber/src/main/java/timber/log/Timber.java
+++ b/timber/src/main/java/timber/log/Timber.java
@@ -236,9 +236,9 @@ public final class Timber {
     void tag(String tag);
   }
 
-  /** A {@link Tree} for debug builds. Automatically infers the tag from the calling class. */
-  public static class DebugTree implements TaggedTree {
-    private static final int MAX_LOG_LENGTH = 4000;
+
+  /** A {@link TaggedTree} that automatically infers the tag from the calling class. */
+  public abstract static class AbstractTaggedTree implements TaggedTree {
     private static final Pattern ANONYMOUS_CLASS = Pattern.compile("\\$\\d+$");
     private static final ThreadLocal<String> NEXT_TAG = new ThreadLocal<String>();
 
@@ -288,6 +288,11 @@ public final class Timber {
       }
       return tag.substring(tag.lastIndexOf('.') + 1);
     }
+  }
+
+  /** A {@link Tree} for debug builds. Automatically infers the tag from the calling class. */
+  public static class DebugTree extends AbstractTaggedTree {
+    private static final int MAX_LOG_LENGTH = 4000;
 
     private static String maybeFormat(String message, Object... args) {
       // If no varargs are supplied, treat it as a request to log the string without formatting.


### PR DESCRIPTION
Fixes #54.

This would allow an implementation of a `Tree` like `CrashReportingTree` that would look like this:
```java
class CrashReportingTree extends Timber.AbstractTaggedTree {
    @Override
    public void i(String message, Object... args) {
        Crashlytics.log(super.createTag() + ": " + String.format(message, args));
    }

    @Override
    public void i(Throwable t, String message, Object... args) {
        i(message, args); // Just add to the log.
    }

    @Override
    public void e(String message, Object... args) {
        i("ERROR: " + message, args); // Just add to the log.
    }

    @Override
    public void e(Throwable t, String message, Object... args) {
        e(message, args);

        Crashlytics.logException(t);
    }
}
```

Thanks to the now available `createTag` :)