### PR TITLE
Decouple Timber from Android.Log

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
 
   <modules>
     <module>timber</module>
+    <module>timber-android</module>
     <module>timber-sample</module>
     <module>timber-lint</module>
   </modules>

--- a/timber-android/pom.xml
+++ b/timber-android/pom.xml
@@ -9,19 +9,36 @@
     <version>3.1.1-SNAPSHOT</version>
   </parent>
 
-  <artifactId>timber-sample</artifactId>
-  <name>Timber Sample</name>
-  <packaging>apk</packaging>
+  <artifactId>timber-android</artifactId>
+  <name>Timber Android</name>
 
   <dependencies>
     <dependency>
       <groupId>com.jakewharton.timber</groupId>
-      <artifactId>timber-android</artifactId>
+      <artifactId>timber</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.jakewharton</groupId>
-      <artifactId>butterknife</artifactId>
+      <groupId>com.jakewharton.timber</groupId>
+      <artifactId>timber</artifactId>
+      <type>test-jar</type>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.robolectric</groupId>
+      <artifactId>robolectric</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.easytesting</groupId>
+      <artifactId>fest-assert-core</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -30,14 +47,4 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>com.simpligility.maven.plugins</groupId>
-        <artifactId>android-maven-plugin</artifactId>
-        <extensions>true</extensions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/timber-android/src/main/java/timber/log/android/DebugTree.java
+++ b/timber-android/src/main/java/timber/log/android/DebugTree.java
@@ -1,0 +1,82 @@
+package timber.log.android;
+
+import android.util.Log;
+import timber.log.Timber;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** A {@link Timber.Tree} for debug builds. Automatically infers the tag from the calling class. */
+public class DebugTree extends Timber.Tree {
+  private static final int MAX_LOG_LENGTH = 4000;
+  private static final int CALL_STACK_INDEX = 5;
+  private static final Pattern ANONYMOUS_CLASS = Pattern.compile("(\\$\\d+)+$");
+
+  /**
+   * Extract the tag which should be used for the message from the {@code element}. By default
+   * this will use the class name without any anonymous class suffixes (e.g., {@code Foo$1}
+   * becomes {@code Foo}).
+   * <p/>
+   * Note: This will not be called if a {@link Timber#tag(String) manual tag} was specified.
+   */
+  protected String createStackElementTag(StackTraceElement element) {
+    String tag = element.getClassName();
+    Matcher m = ANONYMOUS_CLASS.matcher(tag);
+    if (m.find()) {
+      tag = m.replaceAll("");
+    }
+    return tag.substring(tag.lastIndexOf('.') + 1);
+  }
+
+  @Override public final String getTag() {
+    String tag = super.getTag();
+    if (tag != null) {
+      return tag;
+    }
+
+    // DO NOT switch this to Thread.getCurrentThread().getStackTrace(). The test will pass
+    // because Robolectric runs them on the JVM but on Android the elements are different.
+    StackTraceElement[] stackTrace = new Throwable().getStackTrace();
+    if (stackTrace.length <= CALL_STACK_INDEX) {
+      throw new IllegalStateException(
+          "Synthetic stacktrace didn't have enough elements: are you using proguard?");
+    }
+    return createStackElementTag(stackTrace[CALL_STACK_INDEX]);
+  }
+
+  /**
+   * Break up {@code message} into maximum-length chunks (if needed) and send to either
+   * {@link Log#println(int, String, String) Log.println()} or
+   * {@link Log#wtf(String, String) Log.wtf()} for logging.
+   * <p/>
+   * {@inheritDoc}
+   */
+  @Override protected void log(int priority, String tag, String message, Throwable t) {
+    if (message.length() < MAX_LOG_LENGTH) {
+      if (priority == Timber.ASSERT) {
+        Log.wtf(tag, message);
+      } else {
+        Log.println(priority, tag, message);
+      }
+      return;
+    }
+
+    // Split by line, then ensure each line can fit into Log's maximum length.
+    for (int i = 0, length = message.length(); i < length; i++) {
+      int newline = message.indexOf('\n', i);
+      if (newline == -1) {
+        newline = length;
+      }
+      do {
+        int end = Math.min(newline, i + MAX_LOG_LENGTH);
+        String part = message.substring(i, end);
+        if (priority == Log.ASSERT) {
+          Log.wtf(tag, part);
+        } else {
+          Log.println(priority, tag, part);
+        }
+        i = end;
+      } while (i < newline);
+    }
+  }
+}

--- a/timber-android/src/test/java/timber/log/android/DebugTreeTest.java
+++ b/timber-android/src/test/java/timber/log/android/DebugTreeTest.java
@@ -1,0 +1,236 @@
+package timber.log.android;
+
+import android.util.Log;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowLog;
+import timber.log.LogAssert;
+import timber.log.LogItem;
+import timber.log.Timber;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+@RunWith(RobolectricTestRunner.class) //
+@Config(manifest = Config.NONE)
+public class DebugTreeTest {
+  @Before @After public void setUpAndTearDown() {
+    Timber.uprootAll();
+  }
+
+  // NOTE: This class references the line number. Keep it at the top so it does not change.
+  @Test public void debugTreeCanAlterCreatedTag() {
+    Timber.plant(new DebugTree() {
+      @Override protected String createStackElementTag(StackTraceElement element) {
+        return super.createStackElementTag(element) + ':' + element.getLineNumber();
+      }
+    });
+
+    Timber.d("Test");
+
+    assertLog()
+        .hasDebugMessage("DebugTreeTest:37", "Test") // 37 == Line number for Timber.d("Test")
+        .hasNoMoreMessages();
+  }
+
+  @Test public void debugTreeTagGeneration() {
+    Timber.plant(new DebugTree());
+    Timber.d("Hello, world!");
+
+    assertLog()
+        .hasDebugMessage("DebugTreeTest", "Hello, world!")
+        .hasNoMoreMessages();
+  }
+
+  @Test public void debugTreeTagGenerationStripsAnonymousClassMarker() {
+    Timber.plant(new DebugTree());
+    new Runnable() {
+      @Override public void run() {
+        Timber.d("Hello, world!");
+
+        new Runnable() {
+          @Override public void run() {
+            Timber.d("Hello, world!");
+          }
+        }.run();
+      }
+    }.run();
+
+    assertLog()
+        .hasDebugMessage("DebugTreeTest", "Hello, world!")
+        .hasDebugMessage("DebugTreeTest", "Hello, world!")
+        .hasNoMoreMessages();
+  }
+
+  @Test public void debugTreeCustomTag() {
+    Timber.plant(new DebugTree());
+    Timber.tag("Custom").d("Hello, world!");
+
+    assertLog()
+        .hasDebugMessage("Custom", "Hello, world!")
+        .hasNoMoreMessages();
+  }
+
+  @Test public void messageWithException() {
+    Timber.plant(new DebugTree());
+    NullPointerException datThrowable = new NullPointerException();
+    Timber.e(datThrowable, "OMFG!");
+
+    assertLog()
+        .hasErrorMessage("DebugTreeTest", "OMFG!", datThrowable)
+        .hasNoMoreMessages();
+  }
+
+  @Test public void exceptionFromSpawnedThread() throws InterruptedException {
+    Timber.plant(new DebugTree());
+    final NullPointerException datThrowable = new NullPointerException();
+    final CountDownLatch latch = new CountDownLatch(1);
+    new Thread() {
+      @Override public void run() {
+        Timber.e(datThrowable, "OMFG!");
+        latch.countDown();
+      }
+    }.run();
+    latch.await();
+    assertLog()
+        .hasErrorMessage("DebugTreeTest", "OMFG!", datThrowable)
+        .hasNoMoreMessages();
+  }
+
+  @Test public void nullMessageWithThrowable() {
+    Timber.plant(new DebugTree());
+    final NullPointerException datThrowable = new NullPointerException();
+    Timber.e(datThrowable, null);
+
+    assertLog()
+        .hasErrorMessage("DebugTreeTest", "", datThrowable)
+        .hasNoMoreMessages();
+  }
+
+  @Test public void chunkAcrossNewlinesAndLimit() {
+    Timber.plant(new DebugTree());
+    Timber.d(repeat('a', 3000) + '\n' + repeat('b', 6000) + '\n' + repeat('c', 3000));
+
+    assertLog()
+        .hasDebugMessage("DebugTreeTest", repeat('a', 3000))
+        .hasDebugMessage("DebugTreeTest", repeat('b', 4000))
+        .hasDebugMessage("DebugTreeTest", repeat('b', 2000))
+        .hasDebugMessage("DebugTreeTest", repeat('c', 3000))
+        .hasNoMoreMessages();
+  }
+
+  @Test public void nullMessageWithoutThrowable() {
+    Timber.plant(new DebugTree());
+    Timber.d(null);
+
+    assertLog().hasNoMoreMessages();
+  }
+
+  @Test public void logMessageCallback() {
+    final List<String> logs = new ArrayList<String>();
+    Timber.plant(new DebugTree() {
+      @Override protected void log(int priority, String tag, String message, Throwable t) {
+        logs.add(priority + " " + tag + " " + message);
+      }
+    });
+
+    Timber.v("Verbose");
+    Timber.tag("Custom").v("Verbose");
+    Timber.d("Debug");
+    Timber.tag("Custom").d("Debug");
+    Timber.i("Info");
+    Timber.tag("Custom").i("Info");
+    Timber.w("Warn");
+    Timber.tag("Custom").w("Warn");
+    Timber.e("Error");
+    Timber.tag("Custom").e("Error");
+    Timber.wtf("Assert");
+    Timber.tag("Custom").wtf("Assert");
+
+    assertThat(logs).containsExactly(
+        "2 DebugTreeTest Verbose", //
+        "2 Custom Verbose", //
+        "3 DebugTreeTest Debug", //
+        "3 Custom Debug", //
+        "4 DebugTreeTest Info", //
+        "4 Custom Info", //
+        "5 DebugTreeTest Warn", //
+        "5 Custom Warn", //
+        "6 DebugTreeTest Error", //
+        "6 Custom Error", //
+        "7 DebugTreeTest Assert", //
+        "7 Custom Assert" //
+    );
+  }
+
+  @Test public void isLoggableControlsLogging() {
+    Timber.plant(new DebugTree() {
+      @Override
+      protected boolean isLoggable(int priority) {
+        return priority == Log.INFO;
+      }
+    });
+    Timber.v("Hello, World!");
+    Timber.d("Hello, World!");
+    Timber.i("Hello, World!");
+    Timber.w("Hello, World!");
+    Timber.e("Hello, World!");
+
+    assertLog()
+        .hasInfoMessage("DebugTreeTest", "Hello, World!")
+        .hasNoMoreMessages();
+  }
+
+  private static String repeat(char c, int number) {
+    char[] data = new char[number];
+    Arrays.fill(data, c);
+    return new String(data);
+  }
+
+  private static LogAssert assertLog() {
+    return new DebugTreeLogAssert(getLogs());
+  }
+
+  private static List<LogItem> getLogs() {
+    List<ShadowLog.LogItem> robolectricLogItems = ShadowLog.getLogs();
+    List<LogItem> logItems = new ArrayList<LogItem>(robolectricLogItems.size());
+
+    for (ShadowLog.LogItem logItem : robolectricLogItems) {
+      logItems.add(new LogItem(logItem.type, logItem.tag, logItem.msg, logItem.throwable));
+    }
+
+    return logItems;
+  }
+
+  private static class DebugTreeLogAssert extends LogAssert {
+    public DebugTreeLogAssert(List<LogItem> items) {
+      super(items);
+    }
+
+    @Override public LogAssert hasMessage(int priority, String tag, String message, Throwable throwable) {
+      LogItem item = getNextLogItem();
+
+      assertThat(item.type).isEqualTo(priority);
+      assertThat(item.tag).isEqualTo(tag);
+
+      if (throwable != null) {
+        assertThat(item.msg).startsWith(message);
+        assertThat(item.msg).contains(throwable.getClass().getName());
+        // We use a low-level primitive that Robolectric doesn't populate.
+        assertThat(item.throwable).isNull();
+      } else {
+        assertThat(item.msg).isEqualTo(message);
+      }
+
+      return this;
+    }
+  }
+}

--- a/timber-sample/src/main/java/com/example/timber/ExampleApp.java
+++ b/timber-sample/src/main/java/com/example/timber/ExampleApp.java
@@ -3,8 +3,7 @@ package com.example.timber;
 import android.app.Application;
 import android.util.Log;
 import timber.log.Timber;
-
-import static timber.log.Timber.DebugTree;
+import timber.log.android.DebugTree;
 
 public class ExampleApp extends Application {
   @Override public void onCreate() {

--- a/timber/pom.xml
+++ b/timber/pom.xml
@@ -19,20 +19,26 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.robolectric</groupId>
-      <artifactId>robolectric</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.easytesting</groupId>
       <artifactId>fest-assert-core</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>com.google.android</groupId>
-      <artifactId>android</artifactId>
-      <scope>provided</scope>
-    </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.6</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/timber/src/main/java/timber/log/internal/FastPrintWriter.java
+++ b/timber/src/main/java/timber/log/internal/FastPrintWriter.java
@@ -1,0 +1,478 @@
+package timber.log.internal;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
+
+public class FastPrintWriter extends PrintWriter {
+
+  private static Writer sDummyWriter = new Writer() {
+    @Override
+    public void close() throws IOException {
+      UnsupportedOperationException ex
+          = new UnsupportedOperationException("Shouldn't be here");
+      throw ex;
+    }
+
+    @Override
+    public void flush() throws IOException {
+      close();
+    }
+
+    @Override
+    public void write(char[] buf, int offset, int count) throws IOException {
+      close();
+    }
+  };
+
+  private final int mBufferLen;
+  private final char[] mText;
+  private int mPos;
+
+  final private OutputStream mOutputStream;
+  final private boolean mAutoFlush;
+  final private String mSeparator;
+
+  final private Writer mWriter;
+
+  private CharsetEncoder mCharset;
+  final private ByteBuffer mBytes;
+
+  private boolean mIoError;
+
+  /**
+   * Constructs a new {@code PrintWriter} with {@code wr} as its target
+   * writer and a custom buffer size. The parameter {@code autoFlush} determines
+   * if the print writer automatically flushes its contents to the target writer
+   * when a newline is encountered.
+   *
+   * @param wr        the target writer.
+   * @param autoFlush indicates whether to flush contents upon encountering a
+   *                  newline sequence.
+   * @param bufferLen specifies the size of the FastPrintWriter's internal buffer; the
+   *                  default is 8192.
+   * @throws NullPointerException if {@code wr} is {@code null}.
+   */
+  public FastPrintWriter(Writer wr, boolean autoFlush, int bufferLen) {
+    super(sDummyWriter, autoFlush);
+    if (wr == null) {
+      throw new NullPointerException("wr is null");
+    }
+    mBufferLen = bufferLen;
+    mText = new char[bufferLen];
+    mBytes = null;
+    mOutputStream = null;
+    mWriter = wr;
+    mAutoFlush = autoFlush;
+    mSeparator = System.getProperty("line.separator");
+    initDefaultEncoder();
+  }
+
+  /**
+   * Flushes this writer and returns the value of the error flag.
+   *
+   * @return {@code true} if either an {@code IOException} has been thrown
+   * previously or if {@code setError()} has been called;
+   * {@code false} otherwise.
+   * @see #setError()
+   */
+  public boolean checkError() {
+    flush();
+    synchronized (lock) {
+      return mIoError;
+    }
+  }
+
+  /**
+   * Sets the error state of the stream to false.
+   *
+   * @since 1.6
+   */
+  protected void clearError() {
+    synchronized (lock) {
+      mIoError = false;
+    }
+  }
+
+  /**
+   * Sets the error flag of this writer to true.
+   */
+  protected void setError() {
+    synchronized (lock) {
+      mIoError = true;
+    }
+  }
+
+  private void initDefaultEncoder() {
+    mCharset = Charset.defaultCharset().newEncoder();
+    mCharset.onMalformedInput(CodingErrorAction.REPLACE);
+    mCharset.onUnmappableCharacter(CodingErrorAction.REPLACE);
+  }
+
+  private void appendLocked(char c) throws IOException {
+    int pos = mPos;
+    if (pos >= (mBufferLen - 1)) {
+      flushLocked();
+      pos = mPos;
+    }
+    mText[pos] = c;
+    mPos = pos + 1;
+  }
+
+  private void appendLocked(String str, int i, final int length) throws IOException {
+    final int bufferLen = mBufferLen;
+    if (length > bufferLen) {
+      final int end = i + length;
+      while (i < end) {
+        int next = i + bufferLen;
+        appendLocked(str, i, next < end ? bufferLen : (end - i));
+        i = next;
+      }
+      return;
+    }
+    int pos = mPos;
+    if ((pos + length) > bufferLen) {
+      flushLocked();
+      pos = mPos;
+    }
+    str.getChars(i, i + length, mText, pos);
+    mPos = pos + length;
+  }
+
+  private void appendLocked(char[] buf, int i, final int length) throws IOException {
+    final int bufferLen = mBufferLen;
+    if (length > bufferLen) {
+      final int end = i + length;
+      while (i < end) {
+        int next = i + bufferLen;
+        appendLocked(buf, i, next < end ? bufferLen : (end - i));
+        i = next;
+      }
+      return;
+    }
+    int pos = mPos;
+    if ((pos + length) > bufferLen) {
+      flushLocked();
+      pos = mPos;
+    }
+    System.arraycopy(buf, i, mText, pos, length);
+    mPos = pos + length;
+  }
+
+  private void flushBytesLocked() throws IOException {
+    int position = mBytes.position();
+    if (position > 0) {
+      mBytes.flip();
+      mOutputStream.write(mBytes.array(), 0, position);
+      mBytes.clear();
+    }
+  }
+
+  private void flushLocked() throws IOException {
+    //Log.i("PackageManager", "flush mPos=" + mPos);
+    if (mPos > 0) {
+      if (mOutputStream != null) {
+        CharBuffer charBuffer = CharBuffer.wrap(mText, 0, mPos);
+        CoderResult result = mCharset.encode(charBuffer, mBytes, true);
+        while (true) {
+          if (result.isError()) {
+            throw new IOException(result.toString());
+          } else if (result.isOverflow()) {
+            flushBytesLocked();
+            result = mCharset.encode(charBuffer, mBytes, true);
+            continue;
+          }
+          break;
+        }
+        flushBytesLocked();
+        mOutputStream.flush();
+      } else if (mWriter != null) {
+        mWriter.write(mText, 0, mPos);
+        mWriter.flush();
+      }
+      mPos = 0;
+    }
+  }
+
+  /**
+   * Ensures that all pending data is sent out to the target. It also
+   * flushes the target. If an I/O error occurs, this writer's error
+   * state is set to {@code true}.
+   */
+  @Override
+  public void flush() {
+    synchronized (lock) {
+      try {
+        flushLocked();
+        if (mOutputStream != null) {
+          mOutputStream.flush();
+        } else if (mWriter != null) {
+          mWriter.flush();
+        }
+      } catch (IOException e) {
+        setError();
+      }
+    }
+  }
+
+  @Override
+  public void close() {
+    synchronized (lock) {
+      try {
+        flushLocked();
+        if (mOutputStream != null) {
+          mOutputStream.close();
+        } else if (mWriter != null) {
+          mWriter.close();
+        }
+      } catch (IOException e) {
+        setError();
+      }
+    }
+  }
+
+  /**
+   * Prints the string representation of the specified character array
+   * to the target.
+   *
+   * @param charArray the character array to print to the target.
+   * @see #print(String)
+   */
+  public void print(char[] charArray) {
+    synchronized (lock) {
+      try {
+        appendLocked(charArray, 0, charArray.length);
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+  /**
+   * Prints the string representation of the specified character to the
+   * target.
+   *
+   * @param ch the character to print to the target.
+   * @see #print(String)
+   */
+  public void print(char ch) {
+    synchronized (lock) {
+      try {
+        appendLocked(ch);
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+  /**
+   * Prints a string to the target. The string is converted to an array of
+   * bytes using the encoding chosen during the construction of this writer.
+   * The bytes are then written to the target with {@code write(int)}.
+   * <p/>
+   * If an I/O error occurs, this writer's error flag is set to {@code true}.
+   *
+   * @param str the string to print to the target.
+   * @see #write(int)
+   */
+  public void print(String str) {
+    if (str == null) {
+      str = String.valueOf((Object) null);
+    }
+    synchronized (lock) {
+      try {
+        appendLocked(str, 0, str.length());
+      } catch (IOException e) {
+        setError();
+      }
+    }
+  }
+
+
+  @Override
+  public void print(int inum) {
+    if (inum == 0) {
+      print("0");
+    } else {
+      super.print(inum);
+    }
+  }
+
+  @Override
+  public void print(long lnum) {
+    if (lnum == 0) {
+      print("0");
+    } else {
+      super.print(lnum);
+    }
+  }
+
+  /**
+   * Prints a newline. Flushes this writer if the autoFlush flag is set to {@code true}.
+   */
+  public void println() {
+    synchronized (lock) {
+      try {
+        appendLocked(mSeparator, 0, mSeparator.length());
+        if (mAutoFlush) {
+          flushLocked();
+        }
+      } catch (IOException e) {
+        setError();
+      }
+    }
+  }
+
+  @Override
+  public void println(int inum) {
+    if (inum == 0) {
+      println("0");
+    } else {
+      super.println(inum);
+    }
+  }
+
+  @Override
+  public void println(long lnum) {
+    if (lnum == 0) {
+      println("0");
+    } else {
+      super.println(lnum);
+    }
+  }
+
+  /**
+   * Prints the string representation of the character array {@code chars} followed by a newline.
+   * Flushes this writer if the autoFlush flag is set to {@code true}.
+   */
+  public void println(char[] chars) {
+    print(chars);
+    println();
+  }
+
+  /**
+   * Prints the string representation of the char {@code c} followed by a newline.
+   * Flushes this writer if the autoFlush flag is set to {@code true}.
+   */
+  public void println(char c) {
+    print(c);
+    println();
+  }
+
+  /**
+   * Writes {@code count} characters from {@code buffer} starting at {@code
+   * offset} to the target.
+   * <p/>
+   * This writer's error flag is set to {@code true} if this writer is closed
+   * or an I/O error occurs.
+   *
+   * @param buf    the buffer to write to the target.
+   * @param offset the index of the first character in {@code buffer} to write.
+   * @param count  the number of characters in {@code buffer} to write.
+   * @throws IndexOutOfBoundsException if {@code offset < 0} or {@code count < 0}, or if {@code
+   *                                   offset + count} is greater than the length of {@code buf}.
+   */
+  @Override
+  public void write(char[] buf, int offset, int count) {
+    synchronized (lock) {
+      try {
+        appendLocked(buf, offset, count);
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+  /**
+   * Writes one character to the target. Only the two least significant bytes
+   * of the integer {@code oneChar} are written.
+   * <p/>
+   * This writer's error flag is set to {@code true} if this writer is closed
+   * or an I/O error occurs.
+   *
+   * @param oneChar the character to write to the target.
+   */
+  @Override
+  public void write(int oneChar) {
+    synchronized (lock) {
+      try {
+        appendLocked((char) oneChar);
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+  /**
+   * Writes the characters from the specified string to the target.
+   *
+   * @param str the non-null string containing the characters to write.
+   */
+  @Override
+  public void write(String str) {
+    synchronized (lock) {
+      try {
+        appendLocked(str, 0, str.length());
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+  /**
+   * Writes {@code count} characters from {@code str} starting at {@code
+   * offset} to the target.
+   *
+   * @param str    the non-null string containing the characters to write.
+   * @param offset the index of the first character in {@code str} to write.
+   * @param count  the number of characters from {@code str} to write.
+   * @throws IndexOutOfBoundsException if {@code offset < 0} or {@code count < 0}, or if {@code
+   *                                   offset + count} is greater than the length of {@code str}.
+   */
+  @Override
+  public void write(String str, int offset, int count) {
+    synchronized (lock) {
+      try {
+        appendLocked(str, offset, count);
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+  /**
+   * Appends a subsequence of the character sequence {@code csq} to the
+   * target. This method works the same way as {@code
+   * PrintWriter.print(csq.subsequence(start, end).toString())}. If {@code
+   * csq} is {@code null}, then the specified subsequence of the string "null"
+   * will be written to the target.
+   *
+   * @param csq   the character sequence appended to the target.
+   * @param start the index of the first char in the character sequence appended
+   *              to the target.
+   * @param end   the index of the character following the last character of the
+   *              subsequence appended to the target.
+   * @return this writer.
+   * @throws
+   *    StringIndexOutOfBoundsException if {@code start > end}, {@code start < 0}, {@code end < 0}
+   *                                    or either {@code start} or {@code end} are greater or equal
+   *                                    than the length of {@code csq}.
+   */
+  @Override
+  public PrintWriter append(CharSequence csq, int start, int end) {
+    if (csq == null) {
+      csq = "null";
+    }
+    String output = csq.subSequence(start, end).toString();
+    write(output, 0, output.length());
+    return this;
+  }
+
+}

--- a/timber/src/test/java/timber/log/LogAssert.java
+++ b/timber/src/test/java/timber/log/LogAssert.java
@@ -1,0 +1,57 @@
+package timber.log;
+
+import java.util.List;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+public class LogAssert {
+  private final List<LogItem> items;
+  private int index = 0;
+
+  public LogAssert(List<LogItem> items) {
+    this.items = items;
+  }
+
+  public LogAssert hasVerboseMessage(String tag, String message) {
+    return hasMessage(Timber.VERBOSE, tag, message, null);
+  }
+
+  public LogAssert hasDebugMessage(String tag, String message) {
+    return hasMessage(Timber.DEBUG, tag, message, null);
+  }
+
+  public LogAssert hasInfoMessage(String tag, String message) {
+    return hasMessage(Timber.INFO, tag, message, null);
+  }
+
+  public LogAssert hasWarnMessage(String tag, String message) {
+    return hasMessage(Timber.WARN, tag, message, null);
+  }
+
+  public LogAssert hasErrorMessage(String tag, String message) {
+    return hasMessage(Timber.ERROR, tag, message, null);
+  }
+
+  public LogAssert hasErrorMessage(String tag, String message, Throwable throwable) {
+    return hasMessage(Timber.ERROR, tag, message, throwable);
+  }
+
+  public LogAssert hasMessage(int priority, String tag, String message, Throwable throwable) {
+    LogItem item = getNextLogItem();
+
+    assertThat(item.type).isEqualTo(priority);
+    assertThat(item.tag).isEqualTo(tag);
+    assertThat(item.msg).isEqualTo(message);
+    assertThat(item.throwable).isEqualTo(throwable);
+
+    return this;
+  }
+
+  public void hasNoMoreMessages() {
+    assertThat(items).hasSize(index);
+  }
+
+  public LogItem getNextLogItem() {
+    return items.get(index++);
+  }
+}

--- a/timber/src/test/java/timber/log/LogItem.java
+++ b/timber/src/test/java/timber/log/LogItem.java
@@ -1,0 +1,43 @@
+package timber.log;
+
+public class LogItem {
+  public final int type;
+  public final String tag;
+  public final String msg;
+  public final Throwable throwable;
+
+  public LogItem(int type, String tag, String msg, Throwable throwable) {
+    this.type = type;
+    this.tag = tag;
+    this.msg = msg;
+    this.throwable = throwable;
+  }
+
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    LogItem log = (LogItem) o;
+    return type == log.type
+        && !(msg != null ? !msg.equals(log.msg) : log.msg != null)
+        && !(tag != null ? !tag.equals(log.tag) : log.tag != null)
+        && !(throwable != null ? !throwable.equals(log.throwable) : log.throwable != null);
+  }
+
+  @Override public int hashCode() {
+    int result = type;
+    result = 31 * result + (tag != null ? tag.hashCode() : 0);
+    result = 31 * result + (msg != null ? msg.hashCode() : 0);
+    result = 31 * result + (throwable != null ? throwable.hashCode() : 0);
+    return result;
+  }
+
+  @Override public String toString() {
+    return "LogItem{" +
+        "type=" + type +
+        ", tag='" + tag + '\'' +
+        ", msg='" + msg + '\'' +
+        ", throwable=" + throwable +
+        '}';
+  }
+}

--- a/timber/src/test/java/timber/log/TimberTest.java
+++ b/timber/src/test/java/timber/log/TimberTest.java
@@ -1,42 +1,21 @@
 package timber.log;
 
-import android.util.Log;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
-import org.robolectric.shadows.ShadowLog;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
-import static org.robolectric.shadows.ShadowLog.LogItem;
 
-@RunWith(RobolectricTestRunner.class) //
-@Config(manifest = Config.NONE)
 public class TimberTest {
+  private static List<LogItem> logs = new ArrayList<LogItem>();
+
   @Before @After public void setUpAndTearDown() {
     Timber.uprootAll();
-  }
-
-  // NOTE: This class references the line number. Keep it at the top so it does not change.
-  @Test public void debugTreeCanAlterCreatedTag() {
-    Timber.plant(new Timber.DebugTree() {
-      @Override protected String createStackElementTag(StackTraceElement element) {
-        return super.createStackElementTag(element) + ':' + element.getLineNumber();
-      }
-    });
-
-    Timber.d("Test");
-
-    assertLog()
-        .hasDebugMessage("TimberTest:35", "Test")
-        .hasNoMoreMessages();
+    logs.clear();
   }
 
   @Test public void recursion() {
@@ -60,7 +39,7 @@ public class TimberTest {
 
   @Test public void uprootThrowsIfMissing() {
     try {
-      Timber.uproot(new Timber.DebugTree());
+      Timber.uproot(new TestTree());
       fail();
     } catch (IllegalArgumentException e) {
       assertThat(e).hasMessageStartingWith("Cannot uproot tree which is not planted: ");
@@ -68,8 +47,8 @@ public class TimberTest {
   }
 
   @Test public void uprootRemovesTree() {
-    Timber.DebugTree tree1 = new Timber.DebugTree();
-    Timber.DebugTree tree2 = new Timber.DebugTree();
+    TestTree tree1 = new TestTree();
+    TestTree tree2 = new TestTree();
     Timber.plant(tree1);
     Timber.plant(tree2);
     Timber.d("First");
@@ -84,8 +63,8 @@ public class TimberTest {
   }
 
   @Test public void uprootAllRemovesAll() {
-    Timber.DebugTree tree1 = new Timber.DebugTree();
-    Timber.DebugTree tree2 = new Timber.DebugTree();
+    TestTree tree1 = new TestTree();
+    TestTree tree2 = new TestTree();
     Timber.plant(tree1);
     Timber.plant(tree2);
     Timber.d("First");
@@ -98,233 +77,23 @@ public class TimberTest {
         .hasNoMoreMessages();
   }
 
-  @Test public void noArgsDoesNotFormat() {
-    Timber.plant(new Timber.DebugTree());
-    Timber.d("te%st");
-
-    assertLog()
-        .hasDebugMessage("TimberTest", "te%st")
-        .hasNoMoreMessages();
-  }
-
-  @Test public void debugTreeTagGeneration() {
-    Timber.plant(new Timber.DebugTree());
-    Timber.d("Hello, world!");
-
-    assertLog()
-        .hasDebugMessage("TimberTest", "Hello, world!")
-        .hasNoMoreMessages();
-  }
-
-  @Test public void debugTreeTagGenerationStripsAnonymousClassMarker() {
-    Timber.plant(new Timber.DebugTree());
-    new Runnable() {
-      @Override public void run() {
-        Timber.d("Hello, world!");
-
-        new Runnable() {
-          @Override public void run() {
-            Timber.d("Hello, world!");
-          }
-        }.run();
-      }
-    }.run();
-
-    assertLog()
-        .hasDebugMessage("TimberTest", "Hello, world!")
-        .hasDebugMessage("TimberTest", "Hello, world!")
-        .hasNoMoreMessages();
-  }
-
-  @Test public void debugTreeCustomTag() {
-    Timber.plant(new Timber.DebugTree());
-    Timber.tag("Custom").d("Hello, world!");
-
-    assertLog()
-        .hasDebugMessage("Custom", "Hello, world!")
-        .hasNoMoreMessages();
-  }
-
-  @Test public void messageWithException() {
-    Timber.plant(new Timber.DebugTree());
-    NullPointerException datThrowable = new NullPointerException();
-    Timber.e(datThrowable, "OMFG!");
-
-    assertExceptionLogged("OMFG!", "java.lang.NullPointerException");
-  }
-
-  @Test public void exceptionFromSpawnedThread() throws InterruptedException {
-    Timber.plant(new Timber.DebugTree());
-    final NullPointerException datThrowable = new NullPointerException();
-    final CountDownLatch latch = new CountDownLatch(1);
-    new Thread() {
-      @Override public void run() {
-        Timber.e(datThrowable, "OMFG!");
-        latch.countDown();
-      }
-    }.run();
-    latch.await();
-    assertExceptionLogged("OMFG!", "java.lang.NullPointerException");
-  }
-
-  @Test public void nullMessageWithThrowable() {
-    Timber.plant(new Timber.DebugTree());
-    final NullPointerException datThrowable = new NullPointerException();
-    Timber.e(datThrowable, null);
-
-    assertExceptionLogged("", "java.lang.NullPointerException");
-  }
-
-  @Test public void chunkAcrossNewlinesAndLimit() {
-    Timber.plant(new Timber.DebugTree());
-    Timber.d(repeat('a', 3000) + '\n' + repeat('b', 6000) + '\n' + repeat('c', 3000));
-
-    assertLog()
-        .hasDebugMessage("TimberTest", repeat('a', 3000))
-        .hasDebugMessage("TimberTest", repeat('b', 4000))
-        .hasDebugMessage("TimberTest", repeat('b', 2000))
-        .hasDebugMessage("TimberTest", repeat('c', 3000))
-        .hasNoMoreMessages();
-  }
-
-  @Test public void nullMessageWithoutThrowable() {
-    Timber.plant(new Timber.DebugTree());
-    Timber.d(null);
-
-    assertLog().hasNoMoreMessages();
-  }
-
-  @Test public void logMessageCallback() {
-    final List<String> logs = new ArrayList<String>();
-    Timber.plant(new Timber.DebugTree() {
-      @Override protected void log(int priority, String tag, String message, Throwable t) {
-        logs.add(priority + " " + tag + " " + message);
-      }
-    });
-
-    Timber.v("Verbose");
-    Timber.tag("Custom").v("Verbose");
-    Timber.d("Debug");
-    Timber.tag("Custom").d("Debug");
-    Timber.i("Info");
-    Timber.tag("Custom").i("Info");
-    Timber.w("Warn");
-    Timber.tag("Custom").w("Warn");
-    Timber.e("Error");
-    Timber.tag("Custom").e("Error");
-    Timber.wtf("Assert");
-    Timber.tag("Custom").wtf("Assert");
-
-    assertThat(logs).containsExactly( //
-        "2 TimberTest Verbose", //
-        "2 Custom Verbose", //
-        "3 TimberTest Debug", //
-        "3 Custom Debug", //
-        "4 TimberTest Info", //
-        "4 Custom Info", //
-        "5 TimberTest Warn", //
-        "5 Custom Warn", //
-        "6 TimberTest Error", //
-        "6 Custom Error", //
-        "7 TimberTest Assert", //
-        "7 Custom Assert" //
-    );
-  }
-
-  @Test public void formatting() {
-    Timber.plant(new Timber.DebugTree());
-    Timber.v("Hello, %s!", "World");
-    Timber.d("Hello, %s!", "World");
-    Timber.i("Hello, %s!", "World");
-    Timber.w("Hello, %s!", "World");
-    Timber.e("Hello, %s!", "World");
-
-    assertLog()
-        .hasVerboseMessage("TimberTest", "Hello, World!")
-        .hasDebugMessage("TimberTest", "Hello, World!")
-        .hasInfoMessage("TimberTest", "Hello, World!")
-        .hasWarnMessage("TimberTest", "Hello, World!")
-        .hasErrorMessage("TimberTest", "Hello, World!")
-        .hasNoMoreMessages();
-  }
-
-  @Test public void isLoggableControlsLogging() {
-    Timber.plant(new Timber.DebugTree() {
-      @Override protected boolean isLoggable(int priority) {
-        return priority == Log.INFO;
-      }
-    });
-    Timber.v("Hello, World!");
-    Timber.d("Hello, World!");
-    Timber.i("Hello, World!");
-    Timber.w("Hello, World!");
-    Timber.e("Hello, World!");
-
-    assertLog()
-        .hasInfoMessage("TimberTest", "Hello, World!")
-        .hasNoMoreMessages();
-  }
-
-  private static String repeat(char c, int number) {
-    char[] data = new char[number];
-    Arrays.fill(data, c);
-    return new String(data);
-  }
-
-  private static void assertExceptionLogged(String message, String exceptionClassname) {
-    List<LogItem> logs = ShadowLog.getLogs();
-    assertThat(logs).hasSize(1);
-    LogItem log = logs.get(0);
-    assertThat(log.type).isEqualTo(Log.ERROR);
-    assertThat(log.tag).isEqualTo("TimberTest");
-    assertThat(log.msg).startsWith(message);
-    assertThat(log.msg).contains(exceptionClassname);
-    // We use a low-level primitive that Robolectric doesn't populate.
-    assertThat(log.throwable).isNull();
-  }
-
   private static LogAssert assertLog() {
-    return new LogAssert(ShadowLog.getLogs());
+    return new LogAssert(logs);
   }
 
-  private static final class LogAssert {
-    private final List<LogItem> items;
-    private int index = 0;
-
-    private LogAssert(List<LogItem> items) {
-      this.items = items;
+  private static class TestTree extends Timber.Tree {
+    @Override protected void log(int priority, String tag, String message, Throwable t) {
+      logs.add(new LogItem(priority, tag, message, t));
     }
 
-    public LogAssert hasVerboseMessage(String tag, String message) {
-      return hasMessage(Log.VERBOSE, tag, message);
-    }
+    @Override public String getTag() {
+      String tag = super.getTag();
 
-    public LogAssert hasDebugMessage(String tag, String message) {
-      return hasMessage(Log.DEBUG, tag, message);
-    }
+      if (tag != null) {
+        return tag;
+      }
 
-    public LogAssert hasInfoMessage(String tag, String message) {
-      return hasMessage(Log.INFO, tag, message);
-    }
-
-    public LogAssert hasWarnMessage(String tag, String message) {
-      return hasMessage(Log.WARN, tag, message);
-    }
-
-    public LogAssert hasErrorMessage(String tag, String message) {
-      return hasMessage(Log.ERROR, tag, message);
-    }
-
-    private LogAssert hasMessage(int priority, String tag, String message) {
-      LogItem item = items.get(index++);
-      assertThat(item.type).isEqualTo(priority);
-      assertThat(item.tag).isEqualTo(tag);
-      assertThat(item.msg).isEqualTo(message);
-      return this;
-    }
-
-    public void hasNoMoreMessages() {
-      assertThat(items).hasSize(index);
+      return "TimberTest";
     }
   }
 }


### PR DESCRIPTION
Hi Jake!

Few days ago I opened issue #62 asking about the possibility of removing android.Log from Timber class so it can be a pure Java logger. You closed it as a dupe of #29, which asks for making Timber dependent of slf4j-api. I'm not sure these two are asking for the same. 

In order to make my issue more clear I have created this PR as an "illustrative" solution. I know it may not be the best, mainly because it breaks the chain of compatibility for older versions because in favor of a new namespace for DebugTree (timber.log.**android**.DebugTree). But, at least, I hope that you can get a better picture of the goal that I want to achieve.

Look forward to your feedback.

Thanks!
