### PR TITLE
Check if args is not null

### DIFF
--- a/timber/src/main/java/timber/log/Timber.java
+++ b/timber/src/main/java/timber/log/Timber.java
@@ -320,7 +320,7 @@ public final class Timber {
         }
         message = Log.getStackTraceString(t);
       } else {
-        if (args.length > 0) {
+        if (args != null && args.length > 0) {
           message = String.format(message, args);
         }
         if (t != null) {


### PR DESCRIPTION
Sometimes it happens to me that I use something like the following code:

```java
Timber.i("Some text: %s", data);
```

Occasionally data turns out to be null, so it throws a NPE. So I think supporting null arguments is useful (as String.format does).