### PR TITLE
Consumer Proguard rule is added

### DIFF
--- a/timber/build.gradle
+++ b/timber/build.gradle
@@ -23,6 +23,7 @@ android {
 
   defaultConfig {
     minSdkVersion rootProject.ext.minSdkVersion
+    consumerProguardFiles 'consumer-proguard-rules.pro'
   }
 }
 

--- a/timber/consumer-proguard-rules.pro
+++ b/timber/consumer-proguard-rules.pro
@@ -1,0 +1,1 @@
+-dontwarn org.jetbrains.annotations.**


### PR DESCRIPTION
I upgraded to 4.0.1 and got the below Proguard warning:

```
Warning: timber.log.Timber: can't find referenced class org.jetbrains.annotations.NonNls
```

Added `-dontwarn` Proguard config for my project and thought it would help to include consumer proguard config. 