### PR TITLE
Added missing lint check to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ Timber ships with embedded lint rules to detect problems in your app.
             Timber.d("Hello " + firstName + " " + lastName + "!");
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+ *  **ThrowableNotAtBeginning** (Warning) - Detects `Throwable` in the wrong position inside of a `Timber` call. In Timber
+    you have to pass a Throwable at the beginning of the call.
+
+        Example.java:35: Warning: Throwable should be first argument [ThrowableNotAtBeginning]
+            Timber.e("Error occured", e);
+                                     ~~~
+
 
 Download
 --------


### PR DESCRIPTION
I think you missed `ThrowableNotAtBeginning` lint check in the README. 
Since `Throwable`'s are objects, this is the most common Timber usage mistake I am seeing. So :+1: for lint checks and especially for this one.