### PR TITLE
Replace use of Log#getStackTraceString(Throwable)

### DIFF
--- a/timber/src/main/java/timber/log/Timber.java
+++ b/timber/src/main/java/timber/log/Timber.java
@@ -1,6 +1,9 @@
 package timber.log;
 
 import android.util.Log;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -328,17 +331,27 @@ public final class Timber {
         if (t == null) {
           return; // Swallow message if it's null and there's no throwable.
         }
-        message = Log.getStackTraceString(t);
+        message = getStackTraceString(t);
       } else {
         if (args.length > 0) {
           message = String.format(message, args);
         }
         if (t != null) {
-          message += "\n" + Log.getStackTraceString(t);
+          message += "\n" + getStackTraceString(t);
         }
       }
 
       log(priority, getTag(), message, t);
+    }
+
+    private String getStackTraceString(Throwable t) {
+      // Don't replace this with Log.getStackTraceString() - it hides
+      // UnknownHostException, which is not what we want.
+      StringWriter sw = new StringWriter(256);
+      PrintWriter pw = new PrintWriter(sw, false);
+      t.printStackTrace(pw);
+      pw.flush();
+      return sw.toString();
     }
 
     /**

--- a/timber/src/test/java/timber/log/TimberTest.java
+++ b/timber/src/test/java/timber/log/TimberTest.java
@@ -1,6 +1,8 @@
 package timber.log;
 
 import android.util.Log;
+
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -35,7 +37,7 @@ public class TimberTest {
     Timber.d("Test");
 
     assertLog()
-        .hasDebugMessage("TimberTest:35", "Test")
+        .hasDebugMessage("TimberTest:37", "Test")
         .hasNoMoreMessages();
   }
 
@@ -272,6 +274,13 @@ public class TimberTest {
     assertLog()
         .hasInfoMessage("TimberTest", "Hello, World!")
         .hasNoMoreMessages();
+  }
+
+  @Test public void logsUnknownHostExceptions() {
+    Timber.plant(new Timber.DebugTree());
+    Timber.e(new UnknownHostException(), null);
+
+    assertExceptionLogged("", "UnknownHostException");
   }
 
   private static String repeat(char c, int number) {


### PR DESCRIPTION
The built-in method hides UnknownHostException.  This diff adds a method to get a Throwable's stack trace as a string that does not exhibit this behavior.

Fixes #87.