### PR TITLE
Switch to 1-based indexing for arg types check

### DIFF
--- a/timber-lint/src/main/java/timber/lint/WrongTimberUsageDetector.java
+++ b/timber-lint/src/main/java/timber/lint/WrongTimberUsageDetector.java
@@ -220,7 +220,7 @@ public final class WrongTimberUsageDetector extends Detector implements Detector
         if (!valid) {
           String message = String.format("Wrong argument type for formatting argument '#%1$d' "
                   + "in `%2$s`: conversion is '`%3$s`', received `%4$s` "
-                  + "(argument #%5$d in method call)", i, formatString, formatType,
+                  + "(argument #%5$d in method call)", i + 1, formatString, formatType,
               type.getSimpleName(), startIndexOfArguments + i + 1);
           context.report(ISSUE_ARG_TYPES, node, context.getLocation(argument), message);
         }


### PR DESCRIPTION
Per #82 - went ahead and switched both the formatting argument and the method argument to use 1-based indexing; felt like it was more user friendly. (Can switch to 0-based indexing though, these _are_ developers after all)

```
ExampleApp.java:25: Error: Wrong argument type for formatting argument '#1' in success = %b: conversion is 'b', received String (argument #2 in method call) [TimberArgTypes]
    Timber.d("success = %b", taskName);
                             ~~~~~~~~

   Explanation for issues of type "TimberArgTypes":
   The argument types that you specified in your formatting string does not
   match the types of the arguments that you passed to your formatting call.

```