### PR TITLE
change minSdkVersion to 9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ allprojects {
 }
 
 ext {
-  minSdkVersion = 15
+  minSdkVersion = 9
   targetSdkVersion = 23
   compileSdkVersion = 23
   buildToolsVersion = '23.0.1'


### PR DESCRIPTION
Dear Jake Wharton, limiting minSdkVersion to 15 is a big drawback for me using Timber as a useful dependency in my Applications. I change it to 9 and nothing goes wrong, please solve this issue by this pull request.