### PR TITLE
WrongTimberUsageDetectorCrash tag() issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext {
   minSdkVersion = 9
   targetSdkVersion = 23
   compileSdkVersion = 23
-  buildToolsVersion = '23.0.1'
+  buildToolsVersion = '23.0.3'
   sourceCompatibilityVersion = JavaVersion.VERSION_1_7
   targetCompatibilityVersion = JavaVersion.VERSION_1_7
 }
@@ -31,6 +31,6 @@ ext.deps = [
     robolectric: 'org.robolectric:robolectric:3.0',
 
     // Lint dependencies
-    lintapi    : 'com.android.tools.lint:lint-api:24.3.1',
-    lintchecks : 'com.android.tools.lint:lint-checks:24.3.1'
+    lintapi    : 'com.android.tools.lint:lint-api:25.1.0',
+    lintchecks : 'com.android.tools.lint:lint-checks:25.1.0'
 ]

--- a/timber-lint/src/main/java/timber/lint/WrongTimberUsageDetector.java
+++ b/timber-lint/src/main/java/timber/lint/WrongTimberUsageDetector.java
@@ -103,7 +103,7 @@ public final class WrongTimberUsageDetector extends Detector implements Detector
       }
       context.report(ISSUE_FORMAT, node, context.getLocation(node),
           "Using 'String#format' inside of 'Timber'");
-    } else if ("tag".equals(methodName)) {
+    } else if ("tag".equals(methodName) && node.toString().contains("Timber")) {
       VariableReference ref = (VariableReference) node.astOperand();
       if (!"Timber".equals(ref.astIdentifier().astValue())) {
         return;

--- a/timber-sample/src/main/java/com/example/timber/ExampleApp.java
+++ b/timber-sample/src/main/java/com/example/timber/ExampleApp.java
@@ -10,6 +10,7 @@ public class ExampleApp extends Application {
   @Override public void onCreate() {
     super.onCreate();
 
+    new RequestCreator().tag("");
     if (BuildConfig.DEBUG) {
       Timber.plant(new DebugTree());
     } else {
@@ -33,6 +34,12 @@ public class ExampleApp extends Application {
           FakeCrashLibrary.logWarning(t);
         }
       }
+    }
+  }
+
+  private static class RequestCreator {
+    public RequestCreator tag(Object tag) {
+      return this;
     }
   }
 }


### PR DESCRIPTION
When adding `Timber` to my project I kept on getting:

```
Unexpected failure during lint analysis of MyClass.java (this is a bug in lint or one of the libraries it depends on)
WrongTimberUsageDetector.visitMethod(WrongTimberUsageDetector.java:108)<-JavaVisitor$DelegatingJavaVisitor.visitMethodInvocation(JavaVisitor.java:1440)<-MethodInvocation.accept(MethodInvocation.java:114)<-VariableDefinitionEntry.accept(VariableDefinitionEntry.java:105)
```

After some debugging I noticed that the line with the issue was:

```
RequestCreator creator = Picasso.with(myContext).load(myUrl).tag(MY_TAG);
```

I have recreated the issue in the `ExampleApp.java` adding the following line:

```
new RequestCreator().tag("");
```

`methodName` is `tag`, `node` is `node: new RequestCreator().tag("")` but somehow when doing:
`VariableReference ref = (VariableReference) node.astOperand();` the whole thing crashes. 

I would like to find a better approach than checking for "Timber" inside the `node.toString()` but I couldn't :(
