### PR TITLE
Consume tag even when message's priority is not loggable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.1.0'
+    classpath 'com.android.tools.build:gradle:2.1.2'
   }
 }
 

--- a/timber/src/main/java/timber/log/Timber.java
+++ b/timber/src/main/java/timber/log/Timber.java
@@ -382,6 +382,10 @@ public final class Timber {
     }
 
     private void prepareLog(int priority, Throwable t, String message, Object... args) {
+
+      // consume tag, even if priority is not loggable, otherwise next message without explicit tag and loggable, will take erroneous tag
+      final String tag = getTag();
+
       if (!isLoggable(priority)) {
         return;
       }
@@ -402,7 +406,7 @@ public final class Timber {
         }
       }
 
-      log(priority, getTag(), message, t);
+      log(priority, tag, message, t);
     }
 
     private String getStackTraceString(Throwable t) {

--- a/timber/src/main/java/timber/log/Timber.java
+++ b/timber/src/main/java/timber/log/Timber.java
@@ -383,7 +383,7 @@ public final class Timber {
 
     private void prepareLog(int priority, Throwable t, String message, Object... args) {
 
-      // consume tag, even if priority is not loggable, otherwise next message without explicit tag and loggable, will take erroneous tag
+      // Consume tag even when message is not loggable. So that next message is correctly tagged.
       final String tag = getTag();
 
       if (!isLoggable(priority)) {

--- a/timber/src/test/java/timber/log/TimberTest.java
+++ b/timber/src/test/java/timber/log/TimberTest.java
@@ -350,6 +350,20 @@ public class TimberTest {
 
     assertExceptionLogged("", "UnknownHostException");
   }
+  @Test public void tagIsClearedWhenNotLoggable() {
+    Timber.plant(new Timber.DebugTree() {
+      @Override
+      protected boolean isLoggable(int priority) {
+        return priority >= Log.WARN;
+      }
+    });
+    Timber.tag("NotLogged").i("Message not logged");
+    Timber.w("Message logged");
+
+    assertLog()
+        .hasWarnMessage("TimberTest", "Message logged")
+        .hasNoMoreMessages();
+  }
 
   private static String repeat(char c, int number) {
     char[] data = new char[number];


### PR DESCRIPTION
Consume last explicit tag even when message is actually discarded (not loggable priority). So that if next loggable message is without explicit tag, it will correctly use Tree's default.