### PR TITLE
exceptionFromSpawnedThread - Actually test on a spawned thread.

### DIFF
--- a/timber/src/test/java/timber/log/TimberTest.java
+++ b/timber/src/test/java/timber/log/TimberTest.java
@@ -263,7 +263,7 @@ public class TimberTest {
         Timber.e(datThrowable, "OMFG!");
         latch.countDown();
       }
-    }.run();
+    }.start();
     latch.await();
     assertExceptionLogged(Log.ERROR, "OMFG!", "java.lang.NullPointerException");
   }


### PR DESCRIPTION
Going by the name of the test and the presence of the CountdownLatch its obvious the intent was to test execution on a second thread, not direct execution through a Thread object.