### PR TITLE
Add ability to filter logs by log tag.

### DIFF
--- a/timber/src/main/java/timber/log/Timber.java
+++ b/timber/src/main/java/timber/log/Timber.java
@@ -502,16 +502,25 @@ public final class Timber {
       prepareLog(priority, t, null);
     }
 
-    /** Return whether a message at {@code priority} should be logged. */
+    /**
+     * Return whether a message at {@code priority} should be logged.
+     * @deprecated use {@link #isLoggable(String, int)} instead.
+     */
+    @Deprecated
     protected boolean isLoggable(int priority) {
       return true;
+    }
+
+    /** Return whether a message at {@code priority} or {@code tag} should be logged. */
+    protected boolean isLoggable(String tag, int priority) {
+      return isLoggable(priority);
     }
 
     private void prepareLog(int priority, Throwable t, String message, Object... args) {
       // Consume tag even when message is not loggable so that next message is correctly tagged.
       String tag = getTag();
 
-      if (!isLoggable(priority)) {
+      if (!isLoggable(tag, priority)) {
         return;
       }
       if (message != null && message.length() == 0) {

--- a/timber/src/test/java/timber/log/TimberTest.java
+++ b/timber/src/test/java/timber/log/TimberTest.java
@@ -389,6 +389,24 @@ public class TimberTest {
         .hasNoMoreMessages();
   }
 
+  @Test public void isLoggableTagControlsLogging() {
+    Timber.plant(new Timber.DebugTree() {
+      @Override protected boolean isLoggable(String tag, int priority) {
+        return "FILTER".equals(tag);
+      }
+    });
+    Timber.tag("FILTER").v("Hello, World!");
+    Timber.d("Hello, World!");
+    Timber.i("Hello, World!");
+    Timber.w("Hello, World!");
+    Timber.e("Hello, World!");
+    Timber.wtf("Hello, World!");
+
+    assertLog()
+        .hasVerboseMessage("FILTER", "Hello, World!")
+        .hasNoMoreMessages();
+  }
+
   @Test public void logsUnknownHostExceptions() {
     Timber.plant(new Timber.DebugTree());
     Timber.e(new UnknownHostException(), null);


### PR DESCRIPTION
This is a breaking API change, but we call `getTag()` before calling `isLoggable()` and it is useful for filtering.