### PR TITLE
Fix NPE when preparing a log with null args

### DIFF
--- a/timber/src/main/java/timber/log/Timber.java
+++ b/timber/src/main/java/timber/log/Timber.java
@@ -532,7 +532,7 @@ public final class Timber {
         }
         message = getStackTraceString(t);
       } else {
-        if (args.length > 0) {
+        if (args != null && args.length > 0) {
           message = String.format(message, args);
         }
         if (t != null) {

--- a/timber/src/test/java/timber/log/TimberTest.java
+++ b/timber/src/test/java/timber/log/TimberTest.java
@@ -18,6 +18,7 @@ import org.robolectric.shadows.ShadowLog;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeNoException;
 import static org.robolectric.shadows.ShadowLog.LogItem;
 
 @RunWith(RobolectricTestRunner.class) //
@@ -427,6 +428,21 @@ public class TimberTest {
     assertLog()
         .hasWarnMessage("TimberTest", "Message logged")
         .hasNoMoreMessages();
+  }
+
+  @Test public void nullArgsDontThrowException() {
+    Timber.plant(new Timber.DebugTree());
+    try {
+      Timber.e(null, null, (Object[]) null);
+      Timber.e("Message with null args", (Object[]) null);
+      assertLog()
+          .hasErrorMessage("TimberTest", "Message with null args")
+          .hasNoMoreMessages();
+      Timber.e(new Exception("Exception with null message and null args"), null, (Object[]) null);
+      assertExceptionLogged(Log.ERROR, null, "java.lang.Exception", "TimberTest", 1);
+    } catch (Exception e) {
+      assumeNoException(e);
+    }
   }
 
   private static String repeat(char c, int number) {

--- a/timber/src/test/java/timber/log/TimberTest.java
+++ b/timber/src/test/java/timber/log/TimberTest.java
@@ -39,7 +39,7 @@ public class TimberTest {
     Timber.d("Test");
 
     assertLog()
-        .hasDebugMessage("TimberTest:38", "Test")
+        .hasDebugMessage("TimberTest:39", "Test")
         .hasNoMoreMessages();
   }
 


### PR DESCRIPTION
If a log method is invoked with `null` as `args`, `prepareLog()` will throw a `NullPointerException` trying to access its `length` field.
This PR add a `null` check before checking for the length of the array.
