### PR TITLE
Added new log type

### DIFF
--- a/timber/src/main/java/timber/log/Timber.java
+++ b/timber/src/main/java/timber/log/Timber.java
@@ -487,6 +487,15 @@ public final class Timber {
       prepareLog(Log.ASSERT, t, null);
     }
 
+    /** Log a "Loud Assertion" */
+    public void loud(String message) {
+      prepareLog(Log.ASSERT, null,  "============================================== \n" +
+                                    "============================================== \n" +
+                                     message +
+                                    "============================================== \n" +
+                                    "==============================================", null);
+    }
+
     /** Log at {@code priority} a message with optional format args. */
     public void log(int priority, String message, Object... args) {
       prepareLog(priority, null, message, args);


### PR DESCRIPTION
This is of course just a personal preference but I dislike how if a log result is null it just doesn't print the log
Also when scrolling/skimming through logcats this stands out
