### PR TITLE
Fix NoSuchElementException in timber lint.

### DIFF
--- a/timber-lint/src/main/java/timber/lint/WrongTimberUsageDetector.java
+++ b/timber-lint/src/main/java/timber/lint/WrongTimberUsageDetector.java
@@ -113,6 +113,10 @@ public final class WrongTimberUsageDetector extends Detector implements Detector
           return;
         }
       }
+
+      if (node.astArguments().isEmpty()) {
+        return;
+      }
       Node argument = node.astArguments().iterator().next();
       String tag = findLiteralValue(context, argument);
       if (tag != null && tag.length() > 23) {


### PR DESCRIPTION
This fixes the unexpected lint error, it was caused by optimistically assuming the grabbed node has arguments:

NoSuchElementException:ListAccessor$4$1.next(ListAccessor.java:525)<-ListAccessor$4$1.next(ListAccessor.java:502)<-WrongTimberUsageDetector.visitMethod(WrongTimberUsageDetector.java:116)<-JavaVisitor$DelegatingJavaVisitor.visitMethodInvocation(JavaVisitor.java:1442)