### PR TITLE
Revert "Simple implementation"

### DIFF
--- a/timber/src/main/java/timber/log/Timber.java
+++ b/timber/src/main/java/timber/log/Timber.java
@@ -1,6 +1,5 @@
 package timber.log;
 
-import android.text.TextUtils;
 import android.util.Log;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -524,7 +523,10 @@ public final class Timber {
       if (!isLoggable(tag, priority)) {
         return;
       }
-      if (TextUtils.isEmpty(message)) {
+      if (message != null && message.length() == 0) {
+        message = null;
+      }
+      if (message == null) {
         if (t == null) {
           return; // Swallow message if it's null and there's no throwable.
         }


### PR DESCRIPTION
This reverts commit f10e7af1aec0e3628b5597cc8103bc5d2ea3828d.

Simply to avoid this in JUnit tests:

> java.lang.RuntimeException: Method isEmpty in android.text.TextUtils not mocked. See http://g.co/androidstudio/not-mocked for details.