### PR TITLE
Fix lint warning with dates

### DIFF
--- a/timber-lint/src/main/java/timber/lint/WrongTimberUsageDetector.java
+++ b/timber-lint/src/main/java/timber/lint/WrongTimberUsageDetector.java
@@ -29,6 +29,8 @@ import com.intellij.psi.PsiReferenceExpression;
 import com.intellij.psi.PsiType;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -161,58 +163,112 @@ public final class WrongTimberUsageDetector extends Detector implements Detector
             passedArgCount));
       }
 
+      Class type = getType(argument);
+      if (type == null) {
+        continue;
+      }
+
       char last = formatType.charAt(formatType.length() - 1);
       if (formatType.length() >= 2
           && Character.toLowerCase(formatType.charAt(formatType.length() - 2)) == 't') {
         // Date time conversion.
-        // TODO
+        switch(last) {
+          // time
+          case 'H':
+          case 'I':
+          case 'k':
+          case 'l':
+          case 'M':
+          case 'S':
+          case 'L':
+          case 'N':
+          case 'p':
+          case 'z':
+          case 'Z':
+          case 's':
+          case 'Q':
+            // date
+          case 'B':
+          case 'b':
+          case 'h':
+          case 'A':
+          case 'a':
+          case 'C':
+          case 'Y':
+          case 'y':
+          case 'j':
+          case 'm':
+          case 'd':
+          case 'e':
+            // date/time
+          case 'R':
+          case 'T':
+          case 'r':
+          case 'D':
+          case 'F':
+          case 'c':
+            valid = type == Integer.TYPE
+                    || type == Calendar.class
+                    || type == Date.class;
+            if (!valid) {
+              String message = String.format("Wrong argument type for date formatting argument '#%1$d' "
+                              + "in `%2$s`: conversion is '`%3$s`', received `%4$s` "
+                              + "(argument #%5$d in method call)", i + 1, formatString, formatType,
+                      type.getSimpleName(), startIndexOfArguments + i + 1);
+              context.report(ISSUE_ARG_TYPES, call, context.getLocation(argument), message);
+            }
+            break;
+          default:
+            String message = String.format("Wrong suffix for date format '#%1$d' "
+                            + "in `%2$s`: conversion is '`%3$s`', received `%4$s` "
+                            + "(argument #%5$d in method call)", i + 1, formatString, formatType,
+                    type.getSimpleName(), startIndexOfArguments + i + 1);
+            context.report(ISSUE_FORMAT, call, context.getLocation(argument), message);
+        }
         continue;
       }
-      Class type = getType(argument);
-      if (type != null) {
-        switch (last) {
-          case 'b':
-          case 'B':
-            valid = type == Boolean.TYPE;
-            break;
-          case 'x':
-          case 'X':
-          case 'd':
-          case 'o':
-          case 'e':
-          case 'E':
-          case 'f':
-          case 'g':
-          case 'G':
-          case 'a':
-          case 'A':
-            valid = type == Integer.TYPE
-                || type == Float.TYPE
-                || type == Double.TYPE
-                || type == Long.TYPE
-                || type == Byte.TYPE
-                || type == Short.TYPE;
-            break;
-          case 'c':
-          case 'C':
-            valid = type == Character.TYPE;
-            break;
-          case 'h':
-          case 'H':
-            valid = type != Boolean.TYPE && !Number.class.isAssignableFrom(type);
-            break;
-          case 's':
-          case 'S':
-          default:
-            valid = true;
-        }
-        if (!valid) {
-          String message = String.format("Wrong argument type for formatting argument '#%1$d' "
-                  + "in `%2$s`: conversion is '`%3$s`', received `%4$s` "
-                  + "(argument #%5$d in method call)", i + 1, formatString, formatType,
-              type.getSimpleName(), startIndexOfArguments + i + 1);
-          context.report(ISSUE_ARG_TYPES, call, context.getLocation(argument), message);
-        }
+      switch (last) {
+        case 'b':
+        case 'B':
+          valid = type == Boolean.TYPE;
+          break;
+        case 'x':
+        case 'X':
+        case 'd':
+        case 'o':
+        case 'e':
+        case 'E':
+        case 'f':
+        case 'g':
+        case 'G':
+        case 'a':
+        case 'A':
+          valid = type == Integer.TYPE
+              || type == Float.TYPE
+              || type == Double.TYPE
+              || type == Long.TYPE
+              || type == Byte.TYPE
+              || type == Short.TYPE;
+          break;
+        case 'c':
+        case 'C':
+          valid = type == Character.TYPE;
+          break;
+        case 'h':
+        case 'H':
+          valid = type != Boolean.TYPE && !Number.class.isAssignableFrom(type);
+          break;
+        case 's':
+        case 'S':
+        default:
+          valid = true;
+      }
+      if (!valid) {
+        String message = String.format("Wrong argument type for formatting argument '#%1$d' "
+                + "in `%2$s`: conversion is '`%3$s`', received `%4$s` "
+                + "(argument #%5$d in method call)", i + 1, formatString, formatType,
+            type.getSimpleName(), startIndexOfArguments + i + 1);
+        context.report(ISSUE_ARG_TYPES, call, context.getLocation(argument), message);
       }
     }
   }
@@ -346,7 +402,12 @@ public final class WrongTimberUsageDetector extends Detector implements Detector
         if ("%%".equals(str) || "%n".equals(str)) {
           continue;
         }
-        types.add(matcher.group(6));
+        String time = matcher.group(5);
+        if ("t".equalsIgnoreCase(time)) {
+          types.add(time + matcher.group(6));
+        } else {
+          types.add(matcher.group(6));
+        }
       } else {
         break;
       }

--- a/timber-lint/src/test/java/timber/lint/WrongTimberUsageDetectorTest.java
+++ b/timber-lint/src/test/java/timber/lint/WrongTimberUsageDetectorTest.java
@@ -330,6 +330,18 @@ public class WrongTimberUsageDetectorTest extends LintDetectorTest {
     assertThat(lintProject(java(source), timberStub)).isEqualTo(NO_WARNINGS);
   }
 
+  public void testDateFormatNotDisplayingWarning() throws Exception {
+    @Language("JAVA") String source = ""
+        + "package foo;\n"
+        + "import timber.log.Timber;\n"
+        + "public class Example {\n"
+        + "  public void log() {\n"
+        + "    Timber.d(\"%tc\", 567834);\n"
+        + "  }\n"
+        + "}";
+    assertThat(lintProject(java(source), timberStub)).isEqualTo(NO_WARNINGS);
+  }
+
   @Override protected Detector getDetector() {
     return new WrongTimberUsageDetector();
   }

--- a/timber-sample/src/main/java/com/example/timber/ui/DemoActivity.java
+++ b/timber-sample/src/main/java/com/example/timber/ui/DemoActivity.java
@@ -10,6 +10,8 @@ import butterknife.OnClick;
 import com.example.timber.R;
 import timber.log.Timber;
 
+import java.util.Date;
+
 import static android.widget.Toast.LENGTH_SHORT;
 
 public class DemoActivity extends Activity {
@@ -23,7 +25,7 @@ public class DemoActivity extends Activity {
 
   @OnClick({ R.id.hello, R.id.hey, R.id.hi })
   public void greetingClicked(Button button) {
-    Timber.i("A button with ID %s was clicked to say '%s'.", button.getId(), button.getText());
+    Timber.i("A button with ID %s was clicked at %tc to say '%s'.", button.getId(), new Date(), button.getText());
     Toast.makeText(this, "Check logcat for a greeting!", LENGTH_SHORT).show();
   }
 }


### PR DESCRIPTION
This will avoid false positive on dates.
Date format token always start with a `t`/`T` and is followed by a char that will specify the actual format. [1] 

[1] https://docs.oracle.com/javase/7/docs/api/java/util/Formatter.html