### PR TITLE
Fix lint warning with dates

### DIFF
--- a/timber-lint/src/test/java/timber/lint/WrongTimberUsageDetectorTest.java
+++ b/timber-lint/src/test/java/timber/lint/WrongTimberUsageDetectorTest.java
@@ -330,6 +330,18 @@ public class WrongTimberUsageDetectorTest extends LintDetectorTest {
     assertThat(lintProject(java(source), timberStub)).isEqualTo(NO_WARNINGS);
   }
 
+  public void testDateFormatNotDisplayingWarning() throws Exception {
+    @Language("JAVA") String source = ""
+        + "package foo;\n"
+        + "import timber.log.Timber;\n"
+        + "public class Example {\n"
+        + "  public void log() {\n"
+        + "    Timber.d(\"%tc\", new java.util.Date());\n"
+        + "  }\n"
+        + "}";
+    assertThat(lintProject(java(source), timberStub)).isEqualTo(NO_WARNINGS);
+  }
+
   @Override protected Detector getDetector() {
     return new WrongTimberUsageDetector();
   }


### PR DESCRIPTION
This will avoid false positive on dates.
Date format token always start with a `t`/`T` and is followed by a char that will specify the actual format [1].

[1] https://docs.oracle.com/javase/7/docs/api/java/util/Formatter.html