### PR TITLE
Handle wrapped boolean in lint

### DIFF
--- a/timber-lint/src/main/java/timber/lint/WrongTimberUsageDetector.java
+++ b/timber-lint/src/main/java/timber/lint/WrongTimberUsageDetector.java
@@ -355,6 +355,8 @@ public final class WrongTimberUsageDetector extends Detector implements Detector
       } else if ("java.lang.Float".equals(typeClassName) || "java.lang.Double".equals(
           typeClassName)) {
         return Float.TYPE;
+      } else if ("java.lang.Boolean".equals(typeClassName)) {
+        return Boolean.TYPE;
       } else {
         return null;
       }

--- a/timber-lint/src/test/java/timber/lint/WrongTimberUsageDetectorTest.java
+++ b/timber-lint/src/test/java/timber/lint/WrongTimberUsageDetectorTest.java
@@ -342,6 +342,18 @@ public class WrongTimberUsageDetectorTest extends LintDetectorTest {
     assertThat(lintProject(java(source), timberStub)).isEqualTo(NO_WARNINGS);
   }
 
+  public void testWrappedBooleanType() throws Exception {
+    @Language("JAVA") String source = ""
+            + "package foo;\n"
+            + "import timber.log.Timber;\n"
+            + "public class Example {\n"
+            + "  public void log() {\n"
+            + "     Timber.d(\"%b\", Boolean.valueOf(true));\n"
+            + "  }\n"
+            + "}";
+    assertThat(lintProject(java(source), timberStub)).isEqualTo(NO_WARNINGS);
+  }
+
   @Override protected Detector getDetector() {
     return new WrongTimberUsageDetector();
   }


### PR DESCRIPTION
Lint was failing for `%b` format with `Boolean` value. This fixes that issue.