### PR TITLE
Bump lint tools to 25.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ ext {
   buildToolsVersion = '25.0.1'
   sourceCompatibilityVersion = JavaVersion.VERSION_1_7
   targetCompatibilityVersion = JavaVersion.VERSION_1_7
-  lintVersion = '25.2.0'
+  lintVersion = '25.3.0'
 }
 
 ext.deps = [


### PR DESCRIPTION
The Timber lint checks fail when run on projects using the Android Gradle Plugin version 2.3.0 due to breaking changes to the lint apis. Bumping this project to the latest lint tools resolves this.