### PR TITLE
Added method to create a permanently tagged subtree

### DIFF
--- a/timber/src/main/java/timber/log/PermanentlyTaggedTree.java
+++ b/timber/src/main/java/timber/log/PermanentlyTaggedTree.java
@@ -1,0 +1,149 @@
+package timber.log;
+
+import org.jetbrains.annotations.Nullable;
+
+class PermanentlyTaggedTree extends Timber.Tree {
+
+  private final Timber.Tree[] forest;
+
+  private final String permanentTag;
+
+  PermanentlyTaggedTree(Timber.Tree[] forest, String permanentTag) {
+    this.forest = forest;
+    this.permanentTag = permanentTag;
+  }
+
+  @Override
+  public void d(Throwable t) {
+    super.d(t);
+    resetExplicitTag();
+  }
+
+  @Override
+  public void d(String message, Object... args) {
+    super.d(message, args);
+    resetExplicitTag();
+  }
+
+  @Override
+  public void d(Throwable t, String message, Object... args) {
+    super.d(t, message, args);
+    resetExplicitTag();
+  }
+
+
+    @Override
+  public void e(Throwable t) {
+    super.e(t);
+    resetExplicitTag();
+  }
+
+  @Override
+  public void e(String message, Object... args) {
+    super.e(message, args);
+    resetExplicitTag();
+  }
+
+  @Override
+  public void e(Throwable t, String message, Object... args) {
+    super.e(t, message, args);
+    resetExplicitTag();
+  }
+
+
+  @Override
+  public void i(Throwable t) {
+    super.i(t);
+    resetExplicitTag();
+  }
+
+  @Override
+  public void i(String message, Object... args) {
+    super.i(message, args);
+    resetExplicitTag();
+  }
+
+  @Override
+  public void i(Throwable t, String message, Object... args) {
+    super.i(t, message, args);
+    resetExplicitTag();
+  }
+
+  @Override
+  @Nullable String getTag() {
+    final String temporaryTag = explicitTag.get();
+    if (temporaryTag != null) {
+      return temporaryTag;
+    }
+
+    return permanentTag;
+  }
+
+  @Override
+  protected void log(int priority, String tag, String message, Throwable t) {
+    for (Timber.Tree tree : forest) {
+      tree.log(priority, tag, message, t);
+    }
+  }
+
+  private void resetExplicitTag() {
+    if (explicitTag.get() != null) {
+      explicitTag.remove();
+    }
+  }
+
+  @Override
+  public void v(Throwable t) {
+    super.v(t);
+    resetExplicitTag();
+  }
+
+  @Override
+  public void v(String message, Object... args) {
+    super.v(message, args);
+    resetExplicitTag();
+  }
+
+  @Override
+  public void v(Throwable t, String message, Object... args) {
+    super.v(t, message, args);
+    resetExplicitTag();
+  }
+
+  @Override
+  public void w(Throwable t) {
+    super.w(t);
+    resetExplicitTag();
+  }
+
+  @Override
+  public void w(String message, Object... args) {
+    super.w(message, args);
+    resetExplicitTag();
+  }
+
+  @Override
+  public void w(Throwable t, String message, Object... args) {
+    super.w(t, message, args);
+    resetExplicitTag();
+  }
+
+
+  @Override
+  public void wtf(Throwable t) {
+    super.wtf(t);
+    resetExplicitTag();
+  }
+
+  @Override
+  public void wtf(String message, Object... args) {
+    super.wtf(message, args);
+    resetExplicitTag();
+  }
+
+  @Override
+  public void wtf(Throwable t, String message, Object... args) {
+    super.wtf(t, message, args);
+    resetExplicitTag();
+  }
+}

--- a/timber/src/main/java/timber/log/Timber.java
+++ b/timber/src/main/java/timber/log/Timber.java
@@ -142,8 +142,13 @@ public final class Timber {
     return TREE_OF_SOULS;
   }
 
-  public static Tree tagPermanent(String permanentTag) {
-    return new PermanentTagTree(forestAsArray, permanentTag);
+  @SuppressWarnings("ConstantConditions")
+  public static Tree tagged(@SuppressWarnings("SameParameterValue") @NotNull String tag) {
+    if (tag == null) {
+      throw new NullPointerException("tree == null");
+    }
+
+    return new PermanentlyTaggedTree(forestAsArray, tag);
   }
 
   /** Add a new logging tree. */
@@ -387,6 +392,14 @@ public final class Timber {
         explicitTag.remove();
       }
       return tag;
+    }
+
+    /**
+     * Set a one-time tag for use on the next logging call.
+     * This scopes the behaviour of {@link Timber#tag(String)} onto this specific Tree
+     */
+    public void tag(final String tag) {
+      explicitTag.set(tag);
     }
 
     /** Log a verbose message with optional format args. */
@@ -645,24 +658,4 @@ public final class Timber {
     }
   }
 
-  private static class PermanentTagTree extends Tree {
-
-    private final Tree[] forest;
-
-    private final String permanentTag;
-
-
-    PermanentTagTree(Tree[] forest, String permanentTag) {
-      this.forest = forest;
-      this.permanentTag = permanentTag;
-    }
-
-
-    @Override
-    protected void log(int priority, String tag, String message, Throwable t) {
-      for (Tree tree : forest) {
-        tree.log(priority, permanentTag, message, t);
-      }
-    }
-  }
 }

--- a/timber/src/main/java/timber/log/Timber.java
+++ b/timber/src/main/java/timber/log/Timber.java
@@ -142,6 +142,10 @@ public final class Timber {
     return TREE_OF_SOULS;
   }
 
+  public static Tree tagPermanent(String permanentTag) {
+    return new PermanentTagTree(forestAsArray, permanentTag);
+  }
+
   /** Add a new logging tree. */
   @SuppressWarnings("ConstantConditions") // Validating public API contract.
   public static void plant(@NotNull Tree tree) {
@@ -637,6 +641,27 @@ public final class Timber {
           }
           i = end;
         } while (i < newline);
+      }
+    }
+  }
+
+  private static class PermanentTagTree extends Tree {
+
+    private final Tree[] forest;
+
+    private final String permanentTag;
+
+
+    PermanentTagTree(Tree[] forest, String permanentTag) {
+      this.forest = forest;
+      this.permanentTag = permanentTag;
+    }
+
+
+    @Override
+    protected void log(int priority, String tag, String message, Throwable t) {
+      for (Tree tree : forest) {
+        tree.log(priority, permanentTag, message, t);
       }
     }
   }

--- a/timber/src/test/java/timber/log/TimberTest.java
+++ b/timber/src/test/java/timber/log/TimberTest.java
@@ -327,6 +327,26 @@ public class TimberTest {
     assertExceptionLogged(Log.ERROR, "OMFG!", "java.lang.NullPointerException");
   }
 
+  @Test public void keepsPermanentTag() {
+    Timber.plant(new Timber.DebugTree());
+    final Timber.Tree log = Timber.tagPermanent("p");
+
+    log.d("test debug");
+    log.e("test error");
+    log.i("test info");
+    log.v("test verbose");
+    log.w("test warning");
+    log.wtf("test wtf");
+
+    assertLog()
+      .hasDebugMessage("p", "test debug")
+      .hasErrorMessage("p", "test error")
+      .hasInfoMessage("p", "test info")
+      .hasVerboseMessage("p", "test verbose")
+      .hasWarnMessage("p", "test warning")
+      .hasAssertMessage("p", "test wtf"); // LOG_ID_MAIN = 0
+  }
+
   @Test public void nullMessageWithThrowable() {
     Timber.plant(new Timber.DebugTree());
     NullPointerException datThrowable = truncatedThrowable(NullPointerException.class);

--- a/timber/src/test/java/timber/log/TimberTest.java
+++ b/timber/src/test/java/timber/log/TimberTest.java
@@ -329,7 +329,7 @@ public class TimberTest {
 
   @Test public void keepsPermanentTag() {
     Timber.plant(new Timber.DebugTree());
-    final Timber.Tree log = Timber.tagPermanent("p");
+    final Timber.Tree log = Timber.tagged("p");
 
     log.d("test debug");
     log.e("test error");
@@ -345,6 +345,55 @@ public class TimberTest {
       .hasVerboseMessage("p", "test verbose")
       .hasWarnMessage("p", "test warning")
       .hasAssertMessage("p", "test wtf"); // LOG_ID_MAIN = 0
+  }
+
+  @Test public void keepsPermanentTagWithInterrupts() {
+    Timber.plant(new Timber.DebugTree());
+    final Timber.Tree log = Timber.tagged("p");
+
+
+    log.d("test debug");
+    log.tag("debugOverride");
+    log.d("test debug override");
+
+    log.e("test error");
+    log.tag("errorOverride");
+    log.e("test error override");
+
+    log.i("test info");
+    log.tag("infoOverride");
+    log.i("test info override");
+
+    log.v("test verbose");
+    log.tag("verboseOverride");
+    log.v("test verbose override");
+
+    log.w("test warning");
+    log.tag("warningOverride");
+    log.w("test warning override");
+
+    log.wtf("test wtf");
+    log.tag("wtfOverride");
+    log.wtf("test wtf override");
+
+    assertLog()
+        .hasDebugMessage("p", "test debug")
+        .hasDebugMessage("debugOverride", "test debug override")
+
+        .hasErrorMessage("p", "test error")
+        .hasErrorMessage("errorOverride", "test error override")
+
+        .hasInfoMessage("p", "test info")
+        .hasInfoMessage("infoOverride", "test info override")
+
+        .hasVerboseMessage("p", "test verbose")
+        .hasVerboseMessage("verboseOverride", "test verbose override")
+
+        .hasWarnMessage("p", "test warning")
+        .hasWarnMessage("warningOverride", "test warning override")
+
+        .hasAssertMessage("p", "test wtf")
+        .hasAssertMessage("wtfOverride", "test wtf override"); // LOG_ID_MAIN = 0
   }
 
   @Test public void nullMessageWithThrowable() {


### PR DESCRIPTION
Whilst using timber i often found that i would rather be able to specify a permanent tag then relying on Timbers magic to compute the tag. Therefore i added this convinient method to do exactly that.

I don't expect this PR to be accepted right away and  will add additional tests & docs when this even has a chance to be accepted in the main library project.