### PR TITLE
Upgrade to Android Gradle Plugin 3.0.0-alpha8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,13 @@ apply plugin: 'com.github.ben-manes.versions'
 buildscript {
   repositories {
     jcenter()
+    google()
     maven {
       url 'https://plugins.gradle.org/m2/'
     }
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.3'
+    classpath 'com.android.tools.build:gradle:3.0.0-alpha8'
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.15.0'
     classpath 'gradle.plugin.com.kageiit:lintrules:1.1.3'
   }
@@ -18,6 +19,7 @@ allprojects {
   repositories {
     mavenCentral()
     jcenter()
+    google()
   }
 }
 

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-    "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+    "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+    "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
   <!--module name="NewlineAtEndOfFile"/-->
@@ -112,7 +112,7 @@
     <module name="InnerAssignment"/>
     <!--module name="MagicNumber"/-->
     <module name="MissingSwitchDefault"/>
-    <module name="RedundantThrows"/>
+    <!--<module name="RedundantThrows"/>-->
     <module name="SimplifyBooleanExpression"/>
     <module name="SimplifyBooleanReturn"/>
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-rc-1-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-rc-1-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-rc-1-bin.zip

--- a/gradlew
+++ b/gradlew
@@ -33,11 +33,11 @@ DEFAULT_JVM_OPTS=""
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"
 
-warn ( ) {
+warn () {
     echo "$*"
 }
 
-die ( ) {
+die () {
     echo
     echo "$*"
     echo
@@ -155,7 +155,7 @@ if $cygwin ; then
 fi
 
 # Escape application args
-save ( ) {
+save () {
     for i do printf %s\\n "$i" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/' \\\\/" ; done
     echo " "
 }

--- a/timber-lint/build.gradle
+++ b/timber-lint/build.gradle
@@ -4,11 +4,11 @@ targetCompatibility = JavaVersion.VERSION_1_7
 sourceCompatibility = JavaVersion.VERSION_1_7
 
 dependencies {
-  compile deps.lintapi
-  compile deps.lintchecks
-  testCompile deps.lint
-  testCompile deps.linttests
-  testCompile deps.festassert
+  implementation deps.lintapi
+  implementation deps.lintchecks
+  testImplementation deps.lint
+  testImplementation deps.linttests
+  testImplementation deps.festassert
 }
 
 jar {

--- a/timber-sample/build.gradle
+++ b/timber-sample/build.gradle
@@ -25,7 +25,7 @@ android {
 }
 
 dependencies {
-  compile project(':timber')
-  compile 'com.jakewharton:butterknife:8.7.0'
+  implementation project(':timber')
+  implementation 'com.jakewharton:butterknife:8.7.0'
   annotationProcessor 'com.jakewharton:butterknife-compiler:8.7.0'
 }

--- a/timber/build.gradle
+++ b/timber/build.gradle
@@ -34,12 +34,12 @@ android {
 }
 
 dependencies {
-  provided 'org.jetbrains:annotations:15.0'
+  compileOnly 'org.jetbrains:annotations:15.0'
 
-  testCompile deps.festandroid
-  testCompile deps.festassert
-  testCompile deps.junit
-  testCompile deps.robolectric
+  testImplementation deps.festandroid
+  testImplementation deps.festassert
+  testImplementation deps.junit
+  testImplementation deps.robolectric
 
   lintRules project(':timber-lint')
 }

--- a/timber/src/test/java/timber/log/TimberTest.java
+++ b/timber/src/test/java/timber/log/TimberTest.java
@@ -229,7 +229,7 @@ public class TimberTest {
 
   @Test public void messageWithException() {
     Timber.plant(new Timber.DebugTree());
-    NullPointerException datThrowable = new NullPointerException();
+    NullPointerException datThrowable = truncatedThrowable(NullPointerException.class);
     Timber.e(datThrowable, "OMFG!");
 
     assertExceptionLogged(Log.ERROR, "OMFG!", "java.lang.NullPointerException");
@@ -238,50 +238,50 @@ public class TimberTest {
   @Test public void exceptionOnly() {
     Timber.plant(new Timber.DebugTree());
 
-    Timber.v(new IllegalArgumentException());
+    Timber.v(truncatedThrowable(IllegalArgumentException.class));
     assertExceptionLogged(Log.VERBOSE, null, "java.lang.IllegalArgumentException", "TimberTest", 0);
 
-    Timber.i(new NullPointerException());
+    Timber.i(truncatedThrowable(NullPointerException.class));
     assertExceptionLogged(Log.INFO, null, "java.lang.NullPointerException", "TimberTest", 1);
 
-    Timber.d(new UnsupportedOperationException());
+    Timber.d(truncatedThrowable(UnsupportedOperationException.class));
     assertExceptionLogged(Log.DEBUG, null, "java.lang.UnsupportedOperationException", "TimberTest", 2);
 
-    Timber.w(new UnknownHostException());
+    Timber.w(truncatedThrowable(UnknownHostException.class));
     assertExceptionLogged(Log.WARN, null, "java.net.UnknownHostException", "TimberTest", 3);
 
-    Timber.e(new ConnectException());
+    Timber.e(truncatedThrowable(ConnectException.class));
     assertExceptionLogged(Log.ERROR, null, "java.net.ConnectException", "TimberTest", 4);
 
-    Timber.wtf(new AssertionError());
+    Timber.wtf(truncatedThrowable(AssertionError.class));
     assertExceptionLogged(Log.ASSERT, null, "java.lang.AssertionError", "TimberTest", 5);
   }
 
   @Test public void exceptionOnlyCustomTag() {
     Timber.plant(new Timber.DebugTree());
 
-    Timber.tag("Custom").v(new IllegalArgumentException());
+    Timber.tag("Custom").v(truncatedThrowable(IllegalArgumentException.class));
     assertExceptionLogged(Log.VERBOSE, null, "java.lang.IllegalArgumentException", "Custom", 0);
 
-    Timber.tag("Custom").i(new NullPointerException());
+    Timber.tag("Custom").i(truncatedThrowable(NullPointerException.class));
     assertExceptionLogged(Log.INFO, null, "java.lang.NullPointerException", "Custom", 1);
 
-    Timber.tag("Custom").d(new UnsupportedOperationException());
+    Timber.tag("Custom").d(truncatedThrowable(UnsupportedOperationException.class));
     assertExceptionLogged(Log.DEBUG, null, "java.lang.UnsupportedOperationException", "Custom", 2);
 
-    Timber.tag("Custom").w(new UnknownHostException());
+    Timber.tag("Custom").w(truncatedThrowable(UnknownHostException.class));
     assertExceptionLogged(Log.WARN, null, "java.net.UnknownHostException", "Custom", 3);
 
-    Timber.tag("Custom").e(new ConnectException());
+    Timber.tag("Custom").e(truncatedThrowable(ConnectException.class));
     assertExceptionLogged(Log.ERROR, null, "java.net.ConnectException", "Custom", 4);
 
-    Timber.tag("Custom").wtf(new AssertionError());
+    Timber.tag("Custom").wtf(truncatedThrowable(AssertionError.class));
     assertExceptionLogged(Log.ASSERT, null, "java.lang.AssertionError", "Custom", 5);
   }
 
   @Test public void exceptionFromSpawnedThread() throws InterruptedException {
     Timber.plant(new Timber.DebugTree());
-    final NullPointerException datThrowable = new NullPointerException();
+    final NullPointerException datThrowable = truncatedThrowable(NullPointerException.class);
     final CountDownLatch latch = new CountDownLatch(1);
     new Thread() {
       @Override public void run() {
@@ -295,7 +295,7 @@ public class TimberTest {
 
   @Test public void nullMessageWithThrowable() {
     Timber.plant(new Timber.DebugTree());
-    final NullPointerException datThrowable = new NullPointerException();
+    NullPointerException datThrowable = truncatedThrowable(NullPointerException.class);
     Timber.e(datThrowable, null);
 
     assertExceptionLogged(Log.ERROR, "", "java.lang.NullPointerException");
@@ -434,7 +434,7 @@ public class TimberTest {
 
   @Test public void logsUnknownHostExceptions() {
     Timber.plant(new Timber.DebugTree());
-    Timber.e(new UnknownHostException(), null);
+    Timber.e(truncatedThrowable(UnknownHostException.class), null);
 
     assertExceptionLogged(Log.ERROR, "", "UnknownHostException");
   }
@@ -465,6 +465,18 @@ public class TimberTest {
 
     assertLog()
         .hasDebugMessage("TimberTest", "Test formatting: Test message logged. 100");
+  }
+
+  private static <T extends Throwable> T truncatedThrowable(Class<T> throwableClass) {
+    try {
+      T throwable = throwableClass.newInstance();
+      StackTraceElement[] stackTrace = throwable.getStackTrace();
+      int traceLength = stackTrace.length > 5 ? 5 : stackTrace.length;
+      throwable.setStackTrace(Arrays.copyOf(stackTrace, traceLength));
+      return throwable;
+    } catch (InstantiationException | IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   private static String repeat(char c, int number) {


### PR DESCRIPTION
* New dependency configuration syntax
* Add Google Maven repository to allprojects.repositories
* Bump Gradle to 4.1-rc-1
* As of Gradle 3.5-rc-1, the default version of checkstyle is bumped from version 5.9 to 6.19 which removes the RedundantThrows check. 
 See https://github.com/gradle/gradle/commit/12cbf9734b5ea40aadf2a93aecffdbe7d1a959d8 and https://github.com/checkstyle/checkstyle/issues/473.
* As of Gradle 3.4-rc-1, the exceptions created in the unit tests now have a longer
    stack trace due to https://github.com/gradle/gradle/commit/23920dc74bed318ad5238dcd30f3349a606001a3.
    The longer trace passes the Timber.MAX_LOG_LENGTH threshold and is
    split into lines ultimately failing assertions over log size.  This commit includes a fix for this by truncating the stack traces of the created exceptions.