### PR TITLE
Fix custom lint checks

### DIFF
--- a/timber-lint/build.gradle
+++ b/timber-lint/build.gradle
@@ -1,11 +1,11 @@
-apply plugin: 'java'
+apply plugin: 'java-library'
 
 targetCompatibility = JavaVersion.VERSION_1_7
 sourceCompatibility = JavaVersion.VERSION_1_7
 
 dependencies {
-  implementation deps.lintapi
-  implementation deps.lintchecks
+  compileOnly deps.lintapi
+  compileOnly deps.lintchecks
   testImplementation deps.lint
   testImplementation deps.linttests
   testImplementation deps.festassert

--- a/timber-sample/build.gradle
+++ b/timber-sample/build.gradle
@@ -27,5 +27,8 @@ android {
 dependencies {
   implementation project(':timber')
   implementation 'com.jakewharton:butterknife:8.8.1'
+
   annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'
+  
+  lintChecks project(':timber-lint')
 }


### PR DESCRIPTION
* Update lint dependencies to 'compileOnly' configuration
* Update custom lint checks to run on :timber-sample

See https://issuetracker.google.com/issues/62914381#comment23