### PR TITLE
Fix false-positive lint error: Don't check fields as arguments for null

### DIFF
--- a/timber-lint/src/main/java/timber/lint/WrongTimberUsageDetector.java
+++ b/timber-lint/src/main/java/timber/lint/WrongTimberUsageDetector.java
@@ -33,6 +33,7 @@ import org.jetbrains.uast.UExpression;
 import org.jetbrains.uast.UIfExpression;
 import org.jetbrains.uast.UMethod;
 import org.jetbrains.uast.UQualifiedReferenceExpression;
+import org.jetbrains.uast.UReferenceExpression;
 import org.jetbrains.uast.UastBinaryOperator;
 
 import static com.android.tools.lint.client.api.JavaParser.TYPE_BOOLEAN;
@@ -506,9 +507,9 @@ public final class WrongTimberUsageDetector extends Detector implements Detector
 
       if (arg2 instanceof UQualifiedReferenceExpression) {
         UQualifiedReferenceExpression arg2Expression = (UQualifiedReferenceExpression) arg2;
-        UExpression selector = arg2Expression.getSelector();
+        UCallExpression selector = (UCallExpression) arg2Expression.getSelector();
         // what other UExpressions could be a selector?
-        if (isCallFromMethodInSubclassOf(context, (UCallExpression) selector, "getMessage",
+        if (isCallFromMethodInSubclassOf(context, selector, "getMessage",
             "java.lang.Throwable")) {
           LintFix fix = quickFixIssueExceptionLogging(arg2);
           context.report(ISSUE_EXCEPTION_LOGGING, arg2, context.getLocation(call),
@@ -517,11 +518,13 @@ public final class WrongTimberUsageDetector extends Detector implements Detector
         }
       }
 
-      String s = evaluateString(context, arg2, true);
-      if (s == null || s.isEmpty()) {
-        LintFix fix = quickFixIssueExceptionLogging(arg2);
-        context.report(ISSUE_EXCEPTION_LOGGING, arg2, context.getLocation(call),
-            "Use single-argument log method instead of null/empty message", fix);
+      if (!(arg2 instanceof UReferenceExpression)) {
+        String s = evaluateString(context, arg2, true);
+        if (s == null || s.isEmpty()) {
+          LintFix fix = quickFixIssueExceptionLogging(arg2);
+          context.report(ISSUE_EXCEPTION_LOGGING, arg2, context.getLocation(call),
+              "Use single-argument log method instead of null/empty message", fix);
+        }
       }
     }
   }

--- a/timber-lint/src/test/java/timber/lint/WrongTimberUsageDetectorTest.java
+++ b/timber-lint/src/test/java/timber/lint/WrongTimberUsageDetectorTest.java
@@ -649,6 +649,29 @@ public final class WrongTimberUsageDetectorTest {
         .expectClean();
   }
 
+  @Test
+  public void exceptionLoggingUsingField() {
+    lint() //
+        .files(TIMBER_STUB, //
+            java(""
+                + "package foo;\n"
+                + "import timber.log.Timber;\n"
+                + "public class Example {\n"
+                + "  private final String message;\n"
+                + "  public Example(String message) {\n"
+                + "    this.message = message;\n"
+                + "  }\n"
+                + "  public void log() {\n"
+                + "     Exception e = new Exception();\n"
+                + "     Logger.e(e, message);\n"
+                + "  }\n"
+                + "}") //
+        ) //
+        .issues(WrongTimberUsageDetector.ISSUE_EXCEPTION_LOGGING) //
+        .run() //
+        .expectClean();
+  }
+
   @Test public void exceptionLoggingUsingEmptyStringMessage() {
     lint() //
         .files(TIMBER_STUB, //

--- a/timber-lint/src/test/java/timber/lint/WrongTimberUsageDetectorTest.java
+++ b/timber-lint/src/test/java/timber/lint/WrongTimberUsageDetectorTest.java
@@ -657,13 +657,13 @@ public final class WrongTimberUsageDetectorTest {
                 + "package foo;\n"
                 + "import timber.log.Timber;\n"
                 + "public class Example {\n"
-                + "  private final String message;\n"
-                + "  public Example(String message) {\n"
-                + "    this.message = message;\n"
+                + "  private final String logMessage;\n"
+                + "  public Example(String logMessage) {\n"
+                + "    this.logMessage = logMessage;\n"
                 + "  }\n"
                 + "  public void log() {\n"
                 + "     Exception e = new Exception();\n"
-                + "     Logger.e(e, message);\n"
+                + "     Timber.d(e, logMessage);\n"
                 + "  }\n"
                 + "}") //
         ) //


### PR DESCRIPTION
Currently fields for messages are not allowed by the custom lint rules but it is perfectly fine to have such usage. This PR demonstrate the problem by submitting a failing test. 

I'm not sure about the real fix for that. That's why I want to ask here for possible solutions.

The problem is with `ConstantEvaluator.evaluateString` method. This evaluates the constant values. If the parameter is not constant (i.e. a field), this return `null`. Since `null` values are not allowed, this results into false positive lint warning. 

Simply changing line `520` from this `if (s == null || s.isEmpty())` to `if (s != null && s.isEmpty())` fixes the issue described here. But then it fails to check if users put actual `null` as a message. 

If there is a way to check if a given param is the `null` literal, that would be perfect but I couldn't find such thing. 