### PR TITLE
Fix lint NPE

### DIFF
--- a/timber-lint/src/main/java/timber/lint/WrongTimberUsageDetector.java
+++ b/timber-lint/src/main/java/timber/lint/WrongTimberUsageDetector.java
@@ -101,8 +101,9 @@ public final class WrongTimberUsageDetector extends Detector implements Detector
       if (current instanceof UCallExpression) {
         UCallExpression maybeTimberLogCall = (UCallExpression) current;
         JavaEvaluator evaluator = context.getEvaluator();
-        if (Pattern.matches(TIMBER_TREE_LOG_METHOD_REGEXP, maybeTimberLogCall.getMethodName())
-            && evaluator.isMemberInClass(maybeTimberLogCall.resolve(), "timber.log.Timber")) {
+        PsiMethod psiMethod = maybeTimberLogCall.resolve();
+        if (Pattern.matches(TIMBER_TREE_LOG_METHOD_REGEXP, psiMethod.getName())
+            && evaluator.isMemberInClass(psiMethod, "timber.log.Timber")) {
           LintFix fix = quickFixIssueFormat(call);
           context.report(ISSUE_FORMAT, call, context.getLocation(call),
               "Using 'String#format' inside of 'Timber'", fix);

--- a/timber-lint/src/test/java/timber/lint/WrongTimberUsageDetectorTest.java
+++ b/timber-lint/src/test/java/timber/lint/WrongTimberUsageDetectorTest.java
@@ -253,6 +253,22 @@ public final class WrongTimberUsageDetectorTest {
         .expectClean();
   }
 
+  @Test public void validStringFormatInConstructorCall() {
+    lint() //
+        .files(TIMBER_STUB, //
+            java(""
+                + "package foo;\n"
+                + "public class Example {\n"
+                + "  public void log() {\n"
+                + "    new Exception(String.format(\"msg\"));\n"
+                + "  }\n"
+                + "}") //
+        )
+        .issues(WrongTimberUsageDetector.ISSUE_FORMAT)
+        .run()
+        .expectClean();
+  }
+
   @Test public void throwableNotAtBeginning() {
     lint() //
         .files(TIMBER_STUB, //


### PR DESCRIPTION
UCallExpression.getMethodName() returns null when the expression is a
JavaConstructorUCallExpression.

Fixes #256