### PR TITLE
Handle a null args Object[].

### DIFF
--- a/timber/src/main/java/timber/log/Timber.java
+++ b/timber/src/main/java/timber/log/Timber.java
@@ -543,7 +543,7 @@ public final class Timber {
         }
         message = getStackTraceString(t);
       } else {
-        if (args.length > 0) {
+        if (args != null && args.length > 0) {
           message = formatMessage(message, args);
         }
         if (t != null) {

--- a/timber/src/test/java/timber/log/TimberTest.java
+++ b/timber/src/test/java/timber/log/TimberTest.java
@@ -502,6 +502,14 @@ public class TimberTest {
         .hasDebugMessage("TimberTest", "Test formatting: Test message logged. 100");
   }
 
+  @Test public void nullArgumentObjectArray() {
+    Timber.plant(new Timber.DebugTree());
+    Timber.v("Test", (Object[]) null);
+    assertLog()
+        .hasVerboseMessage("TimberTest", "Test")
+        .hasNoMoreMessages();
+  }
+
   private static <T extends Throwable> T truncatedThrowable(Class<T> throwableClass) {
     try {
       T throwable = throwableClass.newInstance();


### PR DESCRIPTION
It's possible that an optimization elides the empty array and chooses to pass null.

Closes #239.