### PR TITLE
Fix nested String.format check

### DIFF
--- a/timber-lint/src/main/java/timber/lint/WrongTimberUsageDetector.java
+++ b/timber-lint/src/main/java/timber/lint/WrongTimberUsageDetector.java
@@ -34,6 +34,7 @@ import org.jetbrains.uast.UIfExpression;
 import org.jetbrains.uast.UMethod;
 import org.jetbrains.uast.UQualifiedReferenceExpression;
 import org.jetbrains.uast.UastBinaryOperator;
+import org.jetbrains.uast.util.UastExpressionUtils;
 
 import static com.android.tools.lint.client.api.JavaParser.TYPE_BOOLEAN;
 import static com.android.tools.lint.client.api.JavaParser.TYPE_BYTE;
@@ -98,12 +99,11 @@ public final class WrongTimberUsageDetector extends Detector implements Detector
         // Reached AST root or code block node; String.format not inside Timber.X(..).
         return;
       }
-      if (current instanceof UCallExpression) {
+      if (UastExpressionUtils.isMethodCall(current)) {
         UCallExpression maybeTimberLogCall = (UCallExpression) current;
         JavaEvaluator evaluator = context.getEvaluator();
         PsiMethod psiMethod = maybeTimberLogCall.resolve();
-        if (psiMethod != null
-            && Pattern.matches(TIMBER_TREE_LOG_METHOD_REGEXP, psiMethod.getName())
+        if (Pattern.matches(TIMBER_TREE_LOG_METHOD_REGEXP, psiMethod.getName())
             && evaluator.isMemberInClass(psiMethod, "timber.log.Timber")) {
           LintFix fix = quickFixIssueFormat(call);
           context.report(ISSUE_FORMAT, call, context.getLocation(call),

--- a/timber-lint/src/test/java/timber/lint/WrongTimberUsageDetectorTest.java
+++ b/timber-lint/src/test/java/timber/lint/WrongTimberUsageDetectorTest.java
@@ -269,7 +269,7 @@ public final class WrongTimberUsageDetectorTest {
         .expectClean();
   }
 
-  @Test public void validStringFormatFromStaticArray() {
+  @Test public void validStringFormatInStaticArray() {
     lint() //
         .files(TIMBER_STUB, //
             java(""


### PR DESCRIPTION
Cleanup of #278; the underlying issue is that there are many types of UCallExpression, but this check only cares about explicit method calls.

<img width="616" alt="screen shot 2017-12-28 at 10 56 08 pm" src="https://user-images.githubusercontent.com/1868149/34429167-694096fe-ec22-11e7-86f5-91ed4aad5e81.png">
