### PR TITLE
Specify Lint api version in the lint check registry

### DIFF
--- a/timber-lint/src/main/java/timber/lint/IssueRegistry.java
+++ b/timber-lint/src/main/java/timber/lint/IssueRegistry.java
@@ -9,4 +9,7 @@ public final class IssueRegistry extends com.android.tools.lint.client.api.Issue
   @Override public List<Issue> getIssues() {
     return Arrays.asList(WrongTimberUsageDetector.getIssues());
   }
+  @Override public int getApi() { 
+    return com.android.tools.lint.detector.api.ApiKt.CURRENT_API; 
+  }
 }


### PR DESCRIPTION
While running Android Lint, I received the following lint warning about the configuration found in Timber's lint. I don't have much experience on this but I just applied what it says. 

<img width="888" alt="screen shot 2018-01-24 at 11 06 37 pm" src="https://user-images.githubusercontent.com/763339/35359739-9212e3d6-015b-11e8-9194-2677d453249a.png">

Hope it will be useful. 