### PR TITLE
Detect Timber usages in lambdas that can be converted to method references

### DIFF
--- a/timber-sample/build.gradle
+++ b/timber-sample/build.gradle
@@ -4,8 +4,8 @@ android {
   compileSdkVersion versions.compileSdk
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_7
-    targetCompatibility JavaVersion.VERSION_1_7
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
   }
 
   defaultConfig {

--- a/timber-sample/src/main/java/com/example/timber/ui/LintActivity.java
+++ b/timber-sample/src/main/java/com/example/timber/ui/LintActivity.java
@@ -70,9 +70,21 @@ public class LintActivity extends Activity {
     Timber.d(new Exception(), "");
     Timber.d(new Exception(), null);
     Timber.d(new Exception().getMessage());
+    errorCallback = new ErrorCallback() {
+      @Override public void run(Throwable t) {
+        Timber.d(t.getMessage());
+      }
+    };
+    errorCallback = t -> Timber.d(t.getMessage());
   }
+
+  ErrorCallback errorCallback;
 
   private String getString() {
     return "foo";
+  }
+
+  interface ErrorCallback {
+    void run(Throwable e);
   }
 }


### PR DESCRIPTION
Thoughts?  The alternative is a two-step Option-Enter combo of first applying the Timber quick fix, then an IntelliJ inspection.
[
<img width="737" alt="screen shot 2018-03-02 at 6 45 28 pm" src="https://user-images.githubusercontent.com/1868149/36927215-1c336d8c-1e4a-11e8-9766-574bb31c5273.png">
](url)