### PR TITLE
Feature/structured logging support

### DIFF
--- a/timber-sample/src/main/java/com/example/timber/ExampleApp.java
+++ b/timber-sample/src/main/java/com/example/timber/ExampleApp.java
@@ -47,7 +47,8 @@ public class ExampleApp extends Application {
       log(priority, tag, message, t, null);
     }
 
-    @Override protected void log(int priority, String tag, @NonNull String message, Throwable t, Map<String, Object> metadata) {
+    @Override protected void log(int priority, String tag, @NonNull String message, Throwable t,
+                                 Map<String, Object> metadata) {
       if (priority == Log.VERBOSE || priority == Log.DEBUG) {
         return;
       }

--- a/timber-sample/src/main/java/com/example/timber/ExampleApp.java
+++ b/timber-sample/src/main/java/com/example/timber/ExampleApp.java
@@ -3,6 +3,9 @@ package com.example.timber;
 import android.app.Application;
 import android.support.annotation.NonNull;
 import android.util.Log;
+
+import java.util.Map;
+
 import timber.log.Timber;
 
 import static timber.log.Timber.DebugTree;
@@ -15,6 +18,7 @@ public class ExampleApp extends Application {
       Timber.plant(new DebugTree());
     } else {
       Timber.plant(new CrashReportingTree());
+      Timber.plant(new StructuredLoggingTree());
     }
   }
 
@@ -34,6 +38,21 @@ public class ExampleApp extends Application {
           FakeCrashLibrary.logWarning(t);
         }
       }
+    }
+  }
+
+  /** A tree which logs important events in a structured format. */
+  private static class StructuredLoggingTree extends Timber.Tree {
+    @Override protected void log(int priority, String tag, @NonNull String message, Throwable t) {
+      log(priority, tag, message, t, null);
+    }
+
+    @Override protected void log(int priority, String tag, @NonNull String message, Throwable t, Map<String, Object> metadata) {
+      if (priority == Log.VERBOSE || priority == Log.DEBUG) {
+        return;
+      }
+
+      FakeCrashLibrary.log(priority, message, metadata);
     }
   }
 }

--- a/timber-sample/src/main/java/com/example/timber/FakeCrashLibrary.java
+++ b/timber-sample/src/main/java/com/example/timber/FakeCrashLibrary.java
@@ -1,9 +1,15 @@
 package com.example.timber;
 
+import java.util.Map;
+
 /** Not a real crash reporting library! */
 public final class FakeCrashLibrary {
   public static void log(int priority, String tag, String message) {
     // TODO add log entry to circular buffer.
+  }
+
+  public static void log(int priority, String message, Map<String, Object> metadata) {
+    // TODO add log entry with metadata
   }
 
   public static void logWarning(Throwable t) {

--- a/timber-sample/src/main/java/com/example/timber/ui/DemoActivity.java
+++ b/timber-sample/src/main/java/com/example/timber/ui/DemoActivity.java
@@ -5,6 +5,9 @@ import android.os.Bundle;
 import android.widget.Button;
 import android.widget.Toast;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import butterknife.ButterKnife;
 import butterknife.OnClick;
 import com.example.timber.R;
@@ -24,6 +27,10 @@ public class DemoActivity extends Activity {
   @OnClick({ R.id.hello, R.id.hey, R.id.hi })
   public void greetingClicked(Button button) {
     Timber.i("A button with ID %s was clicked to say '%s'.", button.getId(), button.getText());
+    Map<String, Object> eventMetadata = new HashMap<>();
+    eventMetadata.put("event-type", "button-pressed");
+    eventMetadata.put("button-id", String.valueOf(button.getId()));
+    Timber.v(eventMetadata, "This is an example of a structured log");
     Toast.makeText(this, "Check logcat for a greeting!", LENGTH_SHORT).show();
   }
 }

--- a/timber/src/main/java/timber/log/Timber.java
+++ b/timber/src/main/java/timber/log/Timber.java
@@ -321,11 +321,28 @@ public final class Timber {
       }
     }
 
+    @Override public void v(Map<String, Object> metadata, String message, Object... args) {
+      Tree[] forest = forestAsArray;
+      //noinspection ForLoopReplaceableByForEach
+      for (int i = 0, count = forest.length; i < count; i++) {
+        forest[i].v(metadata, message, args);
+      }
+    }
+
     @Override public void v(Throwable t, String message, Object... args) {
       Tree[] forest = forestAsArray;
       //noinspection ForLoopReplaceableByForEach
       for (int i = 0, count = forest.length; i < count; i++) {
         forest[i].v(t, message, args);
+      }
+    }
+
+    @Override public void v(Throwable t, Map<String, Object> metadata,
+                            String message, Object... args) {
+      Tree[] forest = forestAsArray;
+      //noinspection ForLoopReplaceableByForEach
+      for (int i = 0, count = forest.length; i < count; i++) {
+        forest[i].v(t, metadata, message, args);
       }
     }
 
@@ -337,11 +354,27 @@ public final class Timber {
       }
     }
 
+    @Override public void v(Map<String, Object> metadata, Throwable t) {
+      Tree[] forest = forestAsArray;
+      //noinspection ForLoopReplaceableByForEach
+      for (int i = 0, count = forest.length; i < count; i++) {
+        forest[i].v(metadata, t);
+      }
+    }
+
     @Override public void d(String message, Object... args) {
       Tree[] forest = forestAsArray;
       //noinspection ForLoopReplaceableByForEach
       for (int i = 0, count = forest.length; i < count; i++) {
         forest[i].d(message, args);
+      }
+    }
+
+    @Override public void d(Map<String, Object> metadata, String message, Object... args) {
+      Tree[] forest = forestAsArray;
+      //noinspection ForLoopReplaceableByForEach
+      for (int i = 0, count = forest.length; i < count; i++) {
+        forest[i].d(metadata, message, args);
       }
     }
 
@@ -353,11 +386,28 @@ public final class Timber {
       }
     }
 
+    @Override public void d(Throwable t, Map<String, Object> metadata,
+                            String message, Object... args) {
+      Tree[] forest = forestAsArray;
+      //noinspection ForLoopReplaceableByForEach
+      for (int i = 0, count = forest.length; i < count; i++) {
+        forest[i].d(t, metadata, message, args);
+      }
+    }
+
     @Override public void d(Throwable t) {
       Tree[] forest = forestAsArray;
       //noinspection ForLoopReplaceableByForEach
       for (int i = 0, count = forest.length; i < count; i++) {
         forest[i].d(t);
+      }
+    }
+
+    @Override public void d(Map<String, Object> metadata, Throwable t) {
+      Tree[] forest = forestAsArray;
+      //noinspection ForLoopReplaceableByForEach
+      for (int i = 0, count = forest.length; i < count; i++) {
+        forest[i].d(metadata, t);
       }
     }
 
@@ -369,11 +419,28 @@ public final class Timber {
       }
     }
 
+    @Override public void i(Map<String, Object> metadata, String message, Object... args) {
+      Tree[] forest = forestAsArray;
+      //noinspection ForLoopReplaceableByForEach
+      for (int i = 0, count = forest.length; i < count; i++) {
+        forest[i].i(metadata, message, args);
+      }
+    }
+
     @Override public void i(Throwable t, String message, Object... args) {
       Tree[] forest = forestAsArray;
       //noinspection ForLoopReplaceableByForEach
       for (int i = 0, count = forest.length; i < count; i++) {
         forest[i].i(t, message, args);
+      }
+    }
+
+    @Override public void i(Throwable t, Map<String, Object> metadata,
+                            String message, Object... args) {
+      Tree[] forest = forestAsArray;
+      //noinspection ForLoopReplaceableByForEach
+      for (int i = 0, count = forest.length; i < count; i++) {
+        forest[i].i(t, metadata, message, args);
       }
     }
 
@@ -385,11 +452,27 @@ public final class Timber {
       }
     }
 
+    @Override public void i(Map<String, Object> metadata, Throwable t) {
+      Tree[] forest = forestAsArray;
+      //noinspection ForLoopReplaceableByForEach
+      for (int i = 0, count = forest.length; i < count; i++) {
+        forest[i].i(metadata, t);
+      }
+    }
+
     @Override public void w(String message, Object... args) {
       Tree[] forest = forestAsArray;
       //noinspection ForLoopReplaceableByForEach
       for (int i = 0, count = forest.length; i < count; i++) {
         forest[i].w(message, args);
+      }
+    }
+
+    @Override public void w(Map<String, Object> metadata, String message, Object... args) {
+      Tree[] forest = forestAsArray;
+      //noinspection ForLoopReplaceableByForEach
+      for (int i = 0, count = forest.length; i < count; i++) {
+        forest[i].w(metadata, message, args);
       }
     }
 
@@ -401,11 +484,28 @@ public final class Timber {
       }
     }
 
+    @Override public void w(Throwable t, Map<String, Object> metadata, String message,
+                            Object... args) {
+      Tree[] forest = forestAsArray;
+      //noinspection ForLoopReplaceableByForEach
+      for (int i = 0, count = forest.length; i < count; i++) {
+        forest[i].w(t, metadata, message, args);
+      }
+    }
+
     @Override public void w(Throwable t) {
       Tree[] forest = forestAsArray;
       //noinspection ForLoopReplaceableByForEach
       for (int i = 0, count = forest.length; i < count; i++) {
         forest[i].w(t);
+      }
+    }
+
+    @Override public void w(Map<String, Object> metadata, Throwable t) {
+      Tree[] forest = forestAsArray;
+      //noinspection ForLoopReplaceableByForEach
+      for (int i = 0, count = forest.length; i < count; i++) {
+        forest[i].w(metadata, t);
       }
     }
 
@@ -417,11 +517,28 @@ public final class Timber {
       }
     }
 
+    @Override public void e(Map<String, Object> metadata, String message, Object... args) {
+      Tree[] forest = forestAsArray;
+      //noinspection ForLoopReplaceableByForEach
+      for (int i = 0, count = forest.length; i < count; i++) {
+        forest[i].e(metadata, message, args);
+      }
+    }
+
     @Override public void e(Throwable t, String message, Object... args) {
       Tree[] forest = forestAsArray;
       //noinspection ForLoopReplaceableByForEach
       for (int i = 0, count = forest.length; i < count; i++) {
         forest[i].e(t, message, args);
+      }
+    }
+
+    @Override public void e(Throwable t, Map<String, Object> metadata, String message,
+                            Object... args) {
+      Tree[] forest = forestAsArray;
+      //noinspection ForLoopReplaceableByForEach
+      for (int i = 0, count = forest.length; i < count; i++) {
+        forest[i].e(t, metadata, message, args);
       }
     }
 
@@ -433,11 +550,27 @@ public final class Timber {
       }
     }
 
+    @Override public void e(Map<String, Object> metadata, Throwable t) {
+      Tree[] forest = forestAsArray;
+      //noinspection ForLoopReplaceableByForEach
+      for (int i = 0, count = forest.length; i < count; i++) {
+        forest[i].e(metadata, t);
+      }
+    }
+
     @Override public void wtf(String message, Object... args) {
       Tree[] forest = forestAsArray;
       //noinspection ForLoopReplaceableByForEach
       for (int i = 0, count = forest.length; i < count; i++) {
         forest[i].wtf(message, args);
+      }
+    }
+
+    @Override public void wtf(Map<String, Object> metadata, String message, Object... args) {
+      Tree[] forest = forestAsArray;
+      //noinspection ForLoopReplaceableByForEach
+      for (int i = 0, count = forest.length; i < count; i++) {
+        forest[i].wtf(metadata, message, args);
       }
     }
 
@@ -449,11 +582,28 @@ public final class Timber {
       }
     }
 
+    @Override public void wtf(Throwable t, Map<String, Object> metadata, String message,
+                              Object... args) {
+      Tree[] forest = forestAsArray;
+      //noinspection ForLoopReplaceableByForEach
+      for (int i = 0, count = forest.length; i < count; i++) {
+        forest[i].wtf(t, metadata, message, args);
+      }
+    }
+
     @Override public void wtf(Throwable t) {
       Tree[] forest = forestAsArray;
       //noinspection ForLoopReplaceableByForEach
       for (int i = 0, count = forest.length; i < count; i++) {
         forest[i].wtf(t);
+      }
+    }
+
+    @Override public void wtf(Map<String, Object> metadata, Throwable t) {
+      Tree[] forest = forestAsArray;
+      //noinspection ForLoopReplaceableByForEach
+      for (int i = 0, count = forest.length; i < count; i++) {
+        forest[i].wtf(metadata, t);
       }
     }
 
@@ -509,7 +659,7 @@ public final class Timber {
 
     @Override protected void log(int priority, String tag, @NotNull String message, Throwable t,
                                  Map<String, Object> metadata) {
-      throw new AssertionError("Missing override for log method.");
+      throw new AssertionError("Missing override for log method. test test");
     }
 
     @Override protected void log(int priority, String tag, @NotNull String message, Throwable t) {

--- a/timber/src/main/java/timber/log/Timber.java
+++ b/timber/src/main/java/timber/log/Timber.java
@@ -25,8 +25,8 @@ public final class Timber {
   }
 
   /** Log a verbose message with metadata and optional format args. */
-  public static void v(Map<String, Object> metaData, @NonNls String message, Object... args) {
-    TREE_OF_SOULS.v(metaData, message, args);
+  public static void v(Map<String, Object> metadata, @NonNls String message, Object... args) {
+    TREE_OF_SOULS.v(metadata, message, args);
   }
 
   /** Log a verbose exception and a message with optional format args. */
@@ -138,7 +138,7 @@ public final class Timber {
   }
 
   /** Log a warning exception with metadata. */
-  public static void w(Map<String,Object> metadata, Throwable t) {
+  public static void w(Map<String, Object> metadata, Throwable t) {
     TREE_OF_SOULS.w(metadata, t);
   }
 
@@ -796,7 +796,7 @@ public final class Timber {
 
     /** Log a warning exception. */
     public void w(Throwable t) {
-      prepareLog(Log.WARN, t, null,null);
+      prepareLog(Log.WARN, t, null, null);
     }
 
     /** Log a warning exception with metadata. */
@@ -826,7 +826,7 @@ public final class Timber {
 
     /** Log an error exception. */
     public void e(Throwable t) {
-      prepareLog(Log.ERROR, t, null,null);
+      prepareLog(Log.ERROR, t, null, null);
     }
 
     /** Log an error exception with metadata. */
@@ -866,7 +866,7 @@ public final class Timber {
 
     /** Log at {@code priority} a message with optional format args. */
     public void log(int priority, String message, Object... args) {
-      prepareLog(priority, null, null, message, args );
+      prepareLog(priority, null, null, message, args);
     }
 
     /** Log at {@code priority} metadata and a message with optional format args. */

--- a/timber/src/main/java/timber/log/Timber.java
+++ b/timber/src/main/java/timber/log/Timber.java
@@ -7,6 +7,7 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jetbrains.annotations.NonNls;
@@ -23,9 +24,20 @@ public final class Timber {
     TREE_OF_SOULS.v(message, args);
   }
 
+  /** Log a verbose message with metadata and optional format args. */
+  public static void v(Map<String, Object> metaData, @NonNls String message, Object... args) {
+    TREE_OF_SOULS.v(metaData, message, args);
+  }
+
   /** Log a verbose exception and a message with optional format args. */
   public static void v(Throwable t, @NonNls String message, Object... args) {
     TREE_OF_SOULS.v(t, message, args);
+  }
+
+  /** Log a verbose exception and a message with optional format args. */
+  public static void v(Throwable t, Map<String, Object> metadata,
+                       @NonNls String message, Object... args) {
+    TREE_OF_SOULS.v(t, metadata, message, args);
   }
 
   /** Log a verbose exception. */
@@ -33,14 +45,29 @@ public final class Timber {
     TREE_OF_SOULS.v(t);
   }
 
+  /** Log a verbose exception with metadata. */
+  public static void v(Map<String, Object> metadata, Throwable t) {
+    TREE_OF_SOULS.v(metadata, t);
+  }
+
   /** Log a debug message with optional format args. */
   public static void d(@NonNls String message, Object... args) {
     TREE_OF_SOULS.d(message, args);
   }
 
+  /** Log a debug message with metadata and optional format args. */
+  public static void d(Map<String, Object> metadata, @NonNls String message, Object... args) {
+    TREE_OF_SOULS.d(metadata, message, args);
+  }
   /** Log a debug exception and a message with optional format args. */
   public static void d(Throwable t, @NonNls String message, Object... args) {
     TREE_OF_SOULS.d(t, message, args);
+  }
+
+  /** Log a debug exception and a message with optional format args. */
+  public static void d(Throwable t, Map<String, Object> metadata,
+                       @NonNls String message, Object... args) {
+    TREE_OF_SOULS.d(t, metadata, message, args);
   }
 
   /** Log a debug exception. */
@@ -48,9 +75,19 @@ public final class Timber {
     TREE_OF_SOULS.d(t);
   }
 
+  /** Log a debug exception with metadata. */
+  public static void d(Map<String, Object> metadata, Throwable t) {
+    TREE_OF_SOULS.d(metadata, t);
+  }
+
   /** Log an info message with optional format args. */
   public static void i(@NonNls String message, Object... args) {
     TREE_OF_SOULS.i(message, args);
+  }
+
+  /** Log an info message with metadata and optional format args. */
+  public static void i(Map<String, Object> metaData, @NonNls String message, Object... args) {
+    TREE_OF_SOULS.i(metaData, message, args);
   }
 
   /** Log an info exception and a message with optional format args. */
@@ -58,9 +95,20 @@ public final class Timber {
     TREE_OF_SOULS.i(t, message, args);
   }
 
+  /** Log an info exception and a message with optional format args. */
+  public static void i(Throwable t, Map<String, Object> metadata,
+                       @NonNls String message, Object... args) {
+    TREE_OF_SOULS.i(t, metadata, message, args);
+  }
+
   /** Log an info exception. */
   public static void i(Throwable t) {
     TREE_OF_SOULS.i(t);
+  }
+
+  /** Log an info exception with metadata. */
+  public static void i(Map<String, Object> metadata, Throwable t) {
+    TREE_OF_SOULS.i(metadata, t);
   }
 
   /** Log a warning message with optional format args. */
@@ -68,9 +116,20 @@ public final class Timber {
     TREE_OF_SOULS.w(message, args);
   }
 
+  /** Log a warning message with metadata and optional format args. */
+  public static void w(Map<String, Object> metaData, @NonNls String message, Object... args) {
+    TREE_OF_SOULS.w(metaData, message, args);
+  }
+
   /** Log a warning exception and a message with optional format args. */
   public static void w(Throwable t, @NonNls String message, Object... args) {
     TREE_OF_SOULS.w(t, message, args);
+  }
+
+  /** Log a verbose exception and a message with optional format args. */
+  public static void w(Throwable t, Map<String, Object> metadata,
+                       @NonNls String message, Object... args) {
+    TREE_OF_SOULS.w(t, metadata, message, args);
   }
 
   /** Log a warning exception. */
@@ -78,9 +137,19 @@ public final class Timber {
     TREE_OF_SOULS.w(t);
   }
 
+  /** Log a warning exception with metadata. */
+  public static void w(Map<String,Object> metadata, Throwable t) {
+    TREE_OF_SOULS.w(metadata, t);
+  }
+
   /** Log an error message with optional format args. */
   public static void e(@NonNls String message, Object... args) {
     TREE_OF_SOULS.e(message, args);
+  }
+
+  /** Log an error message with metadata and optional format args. */
+  public static void e(Map<String, Object> metaData, @NonNls String message, Object... args) {
+    TREE_OF_SOULS.e(metaData, message, args);
   }
 
   /** Log an error exception and a message with optional format args. */
@@ -88,9 +157,20 @@ public final class Timber {
     TREE_OF_SOULS.e(t, message, args);
   }
 
+  /** Log an error exception and a message with optional format args. */
+  public static void e(Throwable t, Map<String, Object> metadata, @NonNls String message,
+                       Object... args) {
+    TREE_OF_SOULS.e(t, metadata, message, args);
+  }
+
   /** Log an error exception. */
   public static void e(Throwable t) {
     TREE_OF_SOULS.e(t);
+  }
+
+  /** Log an error exception with metadata. */
+  public static void e(Map<String, Object> metadata, Throwable t) {
+    TREE_OF_SOULS.e(metadata, t);
   }
 
   /** Log an assert message with optional format args. */
@@ -98,14 +178,30 @@ public final class Timber {
     TREE_OF_SOULS.wtf(message, args);
   }
 
+  /** Log an assert message with metadata and optional format args. */
+  public static void wtf(Map<String, Object> metaData, @NonNls String message, Object... args) {
+    TREE_OF_SOULS.wtf(metaData, message, args);
+  }
+
   /** Log an assert exception and a message with optional format args. */
   public static void wtf(Throwable t, @NonNls String message, Object... args) {
     TREE_OF_SOULS.wtf(t, message, args);
   }
 
+  /** Log an assert exception and a message with optional format args. */
+  public static void wtf(Throwable t, Map<String, Object> metadata, @NonNls String message,
+                         Object... args) {
+    TREE_OF_SOULS.wtf(t, metadata, message, args);
+  }
+
   /** Log an assert exception. */
   public static void wtf(Throwable t) {
     TREE_OF_SOULS.wtf(t);
+  }
+
+  /** Log an assert exception with metadata. */
+  public static void wtf(Map<String, Object> metadata, Throwable t) {
+    TREE_OF_SOULS.wtf(metadata, t);
   }
 
   /** Log at {@code priority} a message with optional format args. */
@@ -369,11 +465,29 @@ public final class Timber {
       }
     }
 
+    @Override public void log(int priority, Map<String, Object> metadata,
+                    String message, Object... args) {
+      Tree[] forest = forestAsArray;
+      //noinspection ForLoopReplaceableByForEach
+      for (int i = 0, count = forest.length; i < count; i++) {
+        forest[i].log(priority, metadata, message, args);
+      }
+    }
+
     @Override public void log(int priority, Throwable t, String message, Object... args) {
       Tree[] forest = forestAsArray;
       //noinspection ForLoopReplaceableByForEach
       for (int i = 0, count = forest.length; i < count; i++) {
         forest[i].log(priority, t, message, args);
+      }
+    }
+
+    @Override public void log(int priority, Throwable t, Map<String, Object> metadata,
+                              String message, Object... args) {
+      Tree[] forest = forestAsArray;
+      //noinspection ForLoopReplaceableByForEach
+      for (int i = 0, count = forest.length; i < count; i++) {
+        forest[i].log(priority, t, metadata, message, args);
       }
     }
 
@@ -383,6 +497,19 @@ public final class Timber {
       for (int i = 0, count = forest.length; i < count; i++) {
         forest[i].log(priority, t);
       }
+    }
+
+    @Override public void log(int priority, Throwable t, Map<String, Object> metadata) {
+      Tree[] forest = forestAsArray;
+      //noinspection ForLoopReplaceableByForEach
+      for (int i = 0, count = forest.length; i < count; i++) {
+        forest[i].log(priority, t, metadata);
+      }
+    }
+
+    @Override protected void log(int priority, String tag, @NotNull String message, Throwable t,
+                                 Map<String, Object> metadata) {
+      throw new AssertionError("Missing override for log method.");
     }
 
     @Override protected void log(int priority, String tag, @NotNull String message, Throwable t) {
@@ -409,107 +536,213 @@ public final class Timber {
 
     /** Log a verbose message with optional format args. */
     public void v(String message, Object... args) {
-      prepareLog(Log.VERBOSE, null, message, args);
+      prepareLog(Log.VERBOSE, null, null, message, args);
+    }
+
+    /** Log a verbose message with metadata and optional format args. */
+    public void v(Map<String, Object> metadata, String message, Object... args) {
+      prepareLog(Log.VERBOSE, null, metadata, message, args);
     }
 
     /** Log a verbose exception and a message with optional format args. */
     public void v(Throwable t, String message, Object... args) {
-      prepareLog(Log.VERBOSE, t, message, args);
+      prepareLog(Log.VERBOSE, t, null, message, args);
+    }
+
+    /** Log a verbose exception with metadata and a message with optional format args. */
+    public void v(Throwable t, Map<String, Object> metadata, String message, Object... args) {
+      prepareLog(Log.VERBOSE, t, metadata, message, args);
     }
 
     /** Log a verbose exception. */
     public void v(Throwable t) {
-      prepareLog(Log.VERBOSE, t, null);
+      prepareLog(Log.VERBOSE, t, null, null);
+    }
+
+    /** Log a verbose exception with metadata. */
+    public void v(Map<String, Object> metadata, Throwable t) {
+      prepareLog(Log.VERBOSE, t, metadata, null);
     }
 
     /** Log a debug message with optional format args. */
     public void d(String message, Object... args) {
-      prepareLog(Log.DEBUG, null, message, args);
+      prepareLog(Log.DEBUG, null, null, message, args);
+    }
+
+    /** Log a debug message with metadata and optional format args. */
+    public void d(Map<String, Object> metadata, String message, Object... args) {
+      prepareLog(Log.DEBUG, null, metadata, message, args);
     }
 
     /** Log a debug exception and a message with optional format args. */
     public void d(Throwable t, String message, Object... args) {
-      prepareLog(Log.DEBUG, t, message, args);
+      prepareLog(Log.DEBUG, t, null, message, args);
+    }
+
+    /** Log a debug exception with metadata and a message with optional format args. */
+    public void d(Throwable t, Map<String, Object> metadata, String message, Object... args) {
+      prepareLog(Log.DEBUG, t, metadata, message, args);
     }
 
     /** Log a debug exception. */
     public void d(Throwable t) {
-      prepareLog(Log.DEBUG, t, null);
+      prepareLog(Log.DEBUG, t, null, null);
+    }
+
+    /** Log a verbose exception with metadata. */
+    public void d(Map<String, Object> metadata, Throwable t) {
+      prepareLog(Log.DEBUG, t, metadata, null);
     }
 
     /** Log an info message with optional format args. */
     public void i(String message, Object... args) {
-      prepareLog(Log.INFO, null, message, args);
+      prepareLog(Log.INFO, null, null, message, args);
+    }
+
+    /** Log an info message with metadata and optional format args. */
+    public void i(Map<String, Object> metadata, String message, Object... args) {
+      prepareLog(Log.INFO, null, metadata, message, args);
     }
 
     /** Log an info exception and a message with optional format args. */
     public void i(Throwable t, String message, Object... args) {
-      prepareLog(Log.INFO, t, message, args);
+      prepareLog(Log.INFO, t, null, message, args);
+    }
+
+    /** Log an info exception with metadata and a message with optional format args. */
+    public void i(Throwable t, Map<String, Object> metadata, String message, Object... args) {
+      prepareLog(Log.INFO, t, metadata, message, args);
     }
 
     /** Log an info exception. */
     public void i(Throwable t) {
-      prepareLog(Log.INFO, t, null);
+      prepareLog(Log.INFO, t, null, null);
+    }
+
+    /** Log an info exception with metadata. */
+    public void i(Map<String, Object> metadata, Throwable t) {
+      prepareLog(Log.INFO, t, metadata, null);
     }
 
     /** Log a warning message with optional format args. */
     public void w(String message, Object... args) {
-      prepareLog(Log.WARN, null, message, args);
+      prepareLog(Log.WARN, null, null, message, args);
+    }
+
+    /** Log a warning message with metadata and optional format args. */
+    public void w(Map<String, Object> metadata, String message, Object... args) {
+      prepareLog(Log.WARN, null, metadata, message, args);
     }
 
     /** Log a warning exception and a message with optional format args. */
     public void w(Throwable t, String message, Object... args) {
-      prepareLog(Log.WARN, t, message, args);
+      prepareLog(Log.WARN, t, null, message, args);
+    }
+
+    /** Log a warning exception with metadata and a message with optional format args. */
+    public void w(Throwable t, Map<String, Object> metadata, String message, Object... args) {
+      prepareLog(Log.WARN, t, metadata, message, args);
     }
 
     /** Log a warning exception. */
     public void w(Throwable t) {
-      prepareLog(Log.WARN, t, null);
+      prepareLog(Log.WARN, t, null,null);
+    }
+
+    /** Log a warning exception with metadata. */
+    public void w(Map<String, Object> metadata, Throwable t) {
+      prepareLog(Log.WARN, t, metadata, null);
     }
 
     /** Log an error message with optional format args. */
     public void e(String message, Object... args) {
-      prepareLog(Log.ERROR, null, message, args);
+      prepareLog(Log.ERROR, null, null, message, args);
+    }
+
+    /** Log an error message with metadata and optional format args. */
+    public void e(Map<String, Object> metadata, String message, Object... args) {
+      prepareLog(Log.ERROR, null, metadata, message, args);
     }
 
     /** Log an error exception and a message with optional format args. */
     public void e(Throwable t, String message, Object... args) {
-      prepareLog(Log.ERROR, t, message, args);
+      prepareLog(Log.ERROR, t, null, message, args);
+    }
+
+    /** Log an error exception with metadata and a message with optional format args. */
+    public void e(Throwable t, Map<String, Object> metadata, String message, Object... args) {
+      prepareLog(Log.ERROR, t, metadata, message, args);
     }
 
     /** Log an error exception. */
     public void e(Throwable t) {
-      prepareLog(Log.ERROR, t, null);
+      prepareLog(Log.ERROR, t, null,null);
+    }
+
+    /** Log an error exception with metadata. */
+    public void e(Map<String, Object> metadata, Throwable t) {
+      prepareLog(Log.ERROR, t, metadata, null);
     }
 
     /** Log an assert message with optional format args. */
     public void wtf(String message, Object... args) {
-      prepareLog(Log.ASSERT, null, message, args);
+      prepareLog(Log.ASSERT, null, null, message, args);
+    }
+
+    /** Log a verbose message with metadata and optional format args. */
+    public void wtf(Map<String, Object> metadata, String message, Object... args) {
+      prepareLog(Log.VERBOSE, null, metadata, message, args);
     }
 
     /** Log an assert exception and a message with optional format args. */
     public void wtf(Throwable t, String message, Object... args) {
-      prepareLog(Log.ASSERT, t, message, args);
+      prepareLog(Log.ASSERT, t, null, message, args);
+    }
+
+    /** Log a verbose exception with metadata and a message with optional format args. */
+    public void wtf(Throwable t, Map<String, Object> metadata, String message, Object... args) {
+      prepareLog(Log.VERBOSE, t, metadata, message, args);
     }
 
     /** Log an assert exception. */
     public void wtf(Throwable t) {
-      prepareLog(Log.ASSERT, t, null);
+      prepareLog(Log.ASSERT, t, null, null);
+    }
+
+    /** Log a verbose exception with metadata. */
+    public void wtf(Map<String, Object> metadata, Throwable t) {
+      prepareLog(Log.VERBOSE, t, metadata, null);
     }
 
     /** Log at {@code priority} a message with optional format args. */
     public void log(int priority, String message, Object... args) {
-      prepareLog(priority, null, message, args);
+      prepareLog(priority, null, null, message, args );
+    }
+
+    /** Log at {@code priority} metadata and a message with optional format args. */
+    public void log(int priority, Map<String, Object> metadata, String message, Object... args) {
+      prepareLog(priority, null, metadata,  message, args);
     }
 
     /** Log at {@code priority} an exception and a message with optional format args. */
     public void log(int priority, Throwable t, String message, Object... args) {
-      prepareLog(priority, t, message, args);
+      prepareLog(priority, t, null, message, args);
+    }
+
+    /** Log at {@code priority} an exception, metadata and a message with optional format args. */
+    public void log(int priority, Throwable t, Map<String, Object> metadata,
+                    String message, Object... args) {
+      prepareLog(priority, t, metadata, message, args);
     }
 
     /** Log at {@code priority} an exception. */
     public void log(int priority, Throwable t) {
-      prepareLog(priority, t, null);
+      prepareLog(priority, t, null, null);
+    }
+
+    /** Log at {@code priority} an exception and metadata. */
+    public void log(int priority, Throwable t, Map<String, Object> metadata) {
+      prepareLog(priority, t, metadata, null);
     }
 
     /**
@@ -527,7 +760,8 @@ public final class Timber {
       return isLoggable(priority);
     }
 
-    private void prepareLog(int priority, Throwable t, String message, Object... args) {
+    private void prepareLog(int priority, Throwable t, Map<String, Object> metadata,
+                            String message, Object... args) {
       // Consume tag even when message is not loggable so that next message is correctly tagged.
       String tag = getTag();
 
@@ -551,7 +785,11 @@ public final class Timber {
         }
       }
 
-      log(priority, tag, message, t);
+      if (metadata == null) {
+        log(priority, tag, message, t);
+      } else {
+        log(priority, tag, message, t, metadata);
+      }
     }
 
     /**
@@ -569,6 +807,20 @@ public final class Timber {
       t.printStackTrace(pw);
       pw.flush();
       return sw.toString();
+    }
+
+    /**
+     * Write a log message to its destination. This must be overridden in order to capture metadata.
+     *
+     * @param priority Log level. See {@link Log} for constants.
+     * @param tag Explicit or inferred tag. May be {@code null}.
+     * @param message Formatted log message. May be {@code null}, but then {@code t} will not be.
+     * @param t Accompanying exceptions. May be {@code null}, but then {@code message} will not be.
+     * @param metadata metadata associated with the log statement. May be {@code null}.
+     */
+    protected void log(int priority, @Nullable String tag, @NotNull String message,
+                                @Nullable Throwable t, @Nullable Map<String, Object> metadata) {
+      throw new IllegalArgumentException("You must override this method to log with metadata");
     }
 
     /**


### PR DESCRIPTION
Implementation of the feature requested in this issue:
https://github.com/JakeWharton/timber/issues/184

This feature would allow Timber to be used in for  [structured logging](https://kartar.net/2015/12/structured-logging/) with SDKs like Firebase and Mint.

The API proposed in this PR adds methods such as:

`public static void v(Map<String, Object> metadata, String message, Object... args)`

I would have preferred to use a more generic Type for metadata instead of prescribing the Type of Map<String, Object>, but I could not find a way to implement generics without breaking the existing API. 