### PR TITLE
Change annotations from a compileOnly to an implementation dependency.

### DIFF
--- a/timber/build.gradle
+++ b/timber/build.gradle
@@ -37,7 +37,7 @@ android {
 }
 
 dependencies {
-  compileOnly deps.annotations
+  implementation deps.annotations
 
   testImplementation deps.annotations
   testImplementation deps.junit


### PR DESCRIPTION
We can't assume that dependent projects will have jetbrains annotations
in the classpath.

This is causing problems like #295.