### PR TITLE
Allow override for tag depth

### DIFF
--- a/timber/src/main/java/timber/log/Timber.java
+++ b/timber/src/main/java/timber/log/Timber.java
@@ -590,6 +590,14 @@ public final class Timber {
       return tag.substring(0, MAX_TAG_LENGTH);
     }
 
+    /**
+     * Define how deep the desired tag will be in the call stack. 5 by default, but may need to
+     * be overridden if you're wrapping Timber or something.
+     */
+    protected int getLoggingDepth() {
+      return CALL_STACK_INDEX;
+    }
+
     @Override final String getTag() {
       String tag = super.getTag();
       if (tag != null) {
@@ -599,11 +607,12 @@ public final class Timber {
       // DO NOT switch this to Thread.getCurrentThread().getStackTrace(). The test will pass
       // because Robolectric runs them on the JVM but on Android the elements are different.
       StackTraceElement[] stackTrace = new Throwable().getStackTrace();
-      if (stackTrace.length <= CALL_STACK_INDEX) {
+      final int callStackIndex = getLoggingDepth();
+      if (stackTrace.length <= callStackIndex) {
         throw new IllegalStateException(
             "Synthetic stacktrace didn't have enough elements: are you using proguard?");
       }
-      return createStackElementTag(stackTrace[CALL_STACK_INDEX]);
+      return createStackElementTag(stackTrace[callStackIndex]);
     }
 
     /**

--- a/timber/src/main/java/timber/log/Timber.java
+++ b/timber/src/main/java/timber/log/Timber.java
@@ -594,7 +594,7 @@ public final class Timber {
      * Define how deep the desired tag will be in the call stack. 5 by default, but may need to
      * be overridden if you're wrapping Timber or something.
      */
-    protected int getLoggingDepth() {
+    protected int getTagDepth() {
       return CALL_STACK_INDEX;
     }
 
@@ -607,7 +607,7 @@ public final class Timber {
       // DO NOT switch this to Thread.getCurrentThread().getStackTrace(). The test will pass
       // because Robolectric runs them on the JVM but on Android the elements are different.
       StackTraceElement[] stackTrace = new Throwable().getStackTrace();
-      final int callStackIndex = getLoggingDepth();
+      final int callStackIndex = getTagDepth();
       if (stackTrace.length <= callStackIndex) {
         throw new IllegalStateException(
             "Synthetic stacktrace didn't have enough elements: are you using proguard?");

--- a/timber/src/test/java/timber/log/TimberTest.java
+++ b/timber/src/test/java/timber/log/TimberTest.java
@@ -510,14 +510,14 @@ public class TimberTest {
         .hasNoMoreMessages();
   }
 
-  @Test public void overrideLoggingDepth() {
+  @Test public void overrideTagDepth() {
     final String expectedTag = TimberTest.class.getSimpleName();
     final String testMessage = "Test message";
 
     Timber.plant(new Timber.DebugTree() {
       @Override
-      protected int getLoggingDepth() {
-        return super.getLoggingDepth() + 1;
+      protected int getTagDepth() {
+        return super.getTagDepth() + 1;
       }
     });
     TimberWrapper.v(testMessage);

--- a/timber/src/test/java/timber/log/TimberTest.java
+++ b/timber/src/test/java/timber/log/TimberTest.java
@@ -510,6 +510,23 @@ public class TimberTest {
         .hasNoMoreMessages();
   }
 
+  @Test public void overrideLoggingDepth() {
+    final String expectedTag = TimberTest.class.getSimpleName();
+    final String testMessage = "Test message";
+
+    Timber.plant(new Timber.DebugTree() {
+      @Override
+      protected int getLoggingDepth() {
+        return 6;
+      }
+    });
+    TimberWrapper.v(testMessage);
+
+    assertLog()
+            .hasVerboseMessage(expectedTag, testMessage)
+            .hasNoMoreMessages();
+  }
+
   private static <T extends Throwable> T truncatedThrowable(Class<T> throwableClass) {
     try {
       T throwable = throwableClass.newInstance();
@@ -595,6 +612,13 @@ public class TimberTest {
 
     public void hasNoMoreMessages() {
       assertThat(items).hasSize(index);
+    }
+  }
+
+  private static final class TimberWrapper {
+
+    public static void v(String message, Object... args) {
+      Timber.v(message, args);
     }
   }
 }

--- a/timber/src/test/java/timber/log/TimberTest.java
+++ b/timber/src/test/java/timber/log/TimberTest.java
@@ -517,7 +517,7 @@ public class TimberTest {
     Timber.plant(new Timber.DebugTree() {
       @Override
       protected int getLoggingDepth() {
-        return 6;
+        return super.getLoggingDepth() + 1;
       }
     });
     TimberWrapper.v(testMessage);


### PR DESCRIPTION
Pull `DebugTree.CALL_STACK_INDEX` into a protected `getLoggingDepth()` method. This is useful for apps that wrap Timber and don't want every tag to be "TimberWrapper" or whatever. Does not affect default behavior for users who don't want/need this.