### PR TITLE
Fix ignored test by using INFO log instead of DEBUG log

### DIFF
--- a/timber/src/test/java/timber/log/TimberTest.java
+++ b/timber/src/test/java/timber/log/TimberTest.java
@@ -224,7 +224,6 @@ public class TimberTest {
         .hasNoMoreMessages();
   }
 
-  @Ignore("Currently failing because wasn't actually asserting before")
   @Test public void debugTreeGeneratedTagIsLoggable() {
     Timber.plant(new Timber.DebugTree() {
       private static final int MAX_TAG_LENGTH = 23;
@@ -243,12 +242,12 @@ public class TimberTest {
     });
     class ClassNameThatIsReallyReallyReallyLong {
       {
-        Timber.d("Hello, world!");
+        Timber.i("Hello, world!");
       }
     }
     new ClassNameThatIsReallyReallyReallyLong();
     assertLog()
-        .hasDebugMessage("TimberTest$1ClassNameTh", "Hello, world!")
+        .hasInfoMessage("TimberTest$1ClassNameTh", "Hello, world!")
         .hasNoMoreMessages();
   }
 


### PR DESCRIPTION
The ignored test in `TimberTest` was failing because `Log.isLoggable()` returns false for all priorities less than `INFO`. I just changed the test to use `Timber.i()` instead of `Timber.d()`.