### PR TITLE
Fix two/three arguments quick fix in Kotlin code

### DIFF
--- a/android-lint/src/main/java/timber/lint/WrongTimberUsageDetector.java
+++ b/android-lint/src/main/java/timber/lint/WrongTimberUsageDetector.java
@@ -652,7 +652,14 @@ public final class WrongTimberUsageDetector extends Detector implements Detector
       throw new IllegalStateException("android.util.Log overloads should have 2 or 3 arguments");
     }
 
-    String logCallSource = logCall.asSourceString();
+    PsiElement psi = logCall.getPsi();
+    UExpression receiver = logCall.getReceiver();
+    String logCallSource;
+    if (psi != null && LintUtils.isKotlin(psi.getLanguage()) && receiver != null) {
+      logCallSource = receiver.asSourceString() + "." + logCall.asSourceString();
+    } else {
+      logCallSource = logCall.asSourceString();
+    }
     LintFix.GroupBuilder fixGrouper = fix().group();
     fixGrouper.add(
         fix().replace().text(logCallSource).shortenNames().reformat(true).with(fixSource1).build());

--- a/android-lint/src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt
+++ b/android-lint/src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt
@@ -51,6 +51,37 @@ class WrongTimberUsageDetectorTest {
             |""".trimMargin())
   }
 
+  @Test fun usingAndroidLogWithTwoArgumentsInKotlin() {
+    lint()
+        .files(
+            kt("""
+                |package foo
+                |import android.util.Log
+                |class Example {
+                |  fun log() {
+                |    Log.d("TAG", "msg")
+                |  }
+                |}""".trimMargin())
+        )
+        .issues(WrongTimberUsageDetector.ISSUE_LOG)
+        .run()
+        .expect("""
+            |src/foo/Example.kt:5: Warning: Using 'Log' instead of 'Timber' [LogNotTimber]
+            |    Log.d("TAG", "msg")
+            |    ~~~~~~~~~~~~~~~~~~~
+            |0 errors, 1 warnings""".trimMargin())
+        .expectFixDiffs("""
+            |Fix for src/foo/Example.kt line 4: Replace with Timber.tag("TAG").d("msg"):
+            |@@ -5 +5
+            |-     Log.d("TAG", "msg")
+            |+     Timber.tag("TAG").d("msg")
+            |Fix for src/foo/Example.kt line 4: Replace with Timber.d("msg"):
+            |@@ -5 +5
+            |-     Log.d("TAG", "msg")
+            |+     Timber.d("msg")
+            |""".trimMargin())
+  }
+
   @Test fun usingAndroidLogWithThreeArguments() {
     lint()
         .files(
@@ -80,6 +111,38 @@ class WrongTimberUsageDetectorTest {
             |-     Log.d("TAG", "msg", new Exception());
             |+     Timber.d(new Exception(), "msg");
             |""".trimMargin())
+  }
+
+  @Test fun usingAndroidLogWithThreeArgumentsInKotlin() {
+    lint()
+        .files(
+            kt("""
+              |package foo
+              |import android.util.Log
+              |class Example {
+              |  fun log() {
+              |    val e = Exception()
+              |    Log.d("TAG", "msg", e)
+              |  }
+              |}""".trimMargin())
+        )
+        .issues(WrongTimberUsageDetector.ISSUE_LOG)
+        .run()
+        .expect("""
+          |src/foo/Example.kt:6: Warning: Using 'Log' instead of 'Timber' [LogNotTimber]
+          |    Log.d("TAG", "msg", e)
+          |    ~~~~~~~~~~~~~~~~~~~~~~
+          |0 errors, 1 warnings""".trimMargin())
+        .expectFixDiffs("""
+          |Fix for src/foo/Example.kt line 5: Replace with Timber.tag("TAG").d(e, "msg"):
+          |@@ -6 +6
+          |-     Log.d("TAG", "msg", e)
+          |+     Timber.tag("TAG").d(e, "msg")
+          |Fix for src/foo/Example.kt line 5: Replace with Timber.d(e, "msg"):
+          |@@ -6 +6
+          |-     Log.d("TAG", "msg", e)
+          |+     Timber.d(e, "msg")
+          |""".trimMargin())
   }
 
   @Test fun usingFullyQualifiedAndroidLogWithTwoArguments() {


### PR DESCRIPTION
## Issue
In Kotlin code, quick fix work incorrectly like below.

**Original code**
```kotlin
class Example {
  fun log() {
    Log.d("TAG", "msg")
  }
}
```

**Quick fixed code**
```kotlin
class Example {
  fun log() {
    Log.Timber.d("TAG", "msg")
  }
}
```

### Environment

- Android Studio 3.1.2
- Android Gradle Plugin 3.1.2

## Cause

Replace source string was created by `logCall.asSourceString()`.
In Java, it will return `Log.d("TAG", "msg")`. But in Kotlin code, just only `d("TAG", "msg")`

