### PR TITLE
Android automatic tag

### DIFF
--- a/android/src/main/java/timber/log/AutomaticTagResolver.kt
+++ b/android/src/main/java/timber/log/AutomaticTagResolver.kt
@@ -1,0 +1,54 @@
+package timber.log
+
+import java.util.regex.Pattern
+
+/**
+ * Can be passed to [LogcatTree]'s constructor in order to treat the class at [callStackIndex] in
+ * the stacktrace as the default tag for the current log. Not recommended for use in release
+ * builds.
+ *
+ * @param callStackIndex How far down the stacktrace to look for the log. Should be 6 if making
+ * normal Timber log calls, could change if wrapping Timber
+ * @param trimFunctionName Trims the function name if present before returning the tag
+ */
+class AutomaticTagResolver(
+    private val callStackIndex: Int = 6,
+    private val trimFunctionName: Boolean = true
+) : () -> String {
+
+  override fun invoke(): String {
+    // DO NOT switch this to Thread.getCurrentThread().getStackTrace(). The test may pass
+    // because Robolectric runs them on the JVM but on Android the elements are different.
+    val stackTrace = Throwable().stackTrace
+
+    if (stackTrace.size <= callStackIndex)
+      throw IllegalStateException("Synthetic stacktrace didn't have enough elements: are you using proguard?")
+
+    return createStackElementTag(stackTrace[callStackIndex])
+  }
+
+  /**
+   * Extract the tag which should be used for the message from the `element`. By default this will use the class name
+   * without any anonymous class suffixes (e.g., `Foo$1` becomes `Foo`).
+   */
+  private fun createStackElementTag(element: StackTraceElement): String {
+    var tag = element.className
+
+    // Remove anonymous class signifiers (e.g. "$1") from the tag:
+    val matcher = ANONYMOUS_CLASS_PATTERN.matcher(tag)
+    if (matcher.find())
+      tag = matcher.replaceAll("")
+
+    // Remove leading package name (e.g. "com.jakewharton.timber.log.") and potential trailing function name (e.g.
+    // "$yourFunction") from the tag:
+    val tagEnd =
+        if (trimFunctionName && tag.contains(FUNCTION_SIGNIFIER)) tag.indexOf(FUNCTION_SIGNIFIER)
+        else tag.length
+    return tag.substring(tag.lastIndexOf('.') + 1, tagEnd)
+  }
+
+  private companion object {
+    const val FUNCTION_SIGNIFIER = '$'
+    private val ANONYMOUS_CLASS_PATTERN = Pattern.compile("(\\$\\d+)+$")
+  }
+}

--- a/android/src/main/java/timber/log/LogcatTree.kt
+++ b/android/src/main/java/timber/log/LogcatTree.kt
@@ -19,7 +19,11 @@ private const val MAX_TAG_LENGTH = 23
  * Note: This does not check [Log.isLoggable] by default. Call [withCompliantLogging] for an
  * instance which delegates to this method prior to logging.
  */
-class LogcatTree @JvmOverloads constructor(private val defaultTag: String = "App") : Tree() {
+class LogcatTree constructor(private val tagResolver: () -> String) : Tree() {
+
+  @JvmOverloads
+  constructor(defaultTag: String = "App") : this({ defaultTag })
+
   /** Return a new [Tree] that checks [Log.isLoggable] prior to logging. */
   fun withCompliantLogging() = object : Tree() {
     override fun isLoggable(priority: Int, tag: String?): Boolean {
@@ -78,7 +82,7 @@ class LogcatTree @JvmOverloads constructor(private val defaultTag: String = "App
   }
 
   private fun String?.asSafeTag(): String {
-    val tag = this ?: defaultTag
+    val tag = this ?: tagResolver.invoke()
     // Tag length limit was removed in API 24.
     if (Build.VERSION.SDK_INT < 24 && tag.length > MAX_TAG_LENGTH) {
       return tag.substring(0, MAX_TAG_LENGTH)


### PR DESCRIPTION
Implement the option of automatic tagging—similar to Timber 4 and earlier—in `LogcatTree`.

How it works: Instead of only accepting a `String` as the default tag in its constructor, `LogcatTree` now also accepts a `() -> String`. This `tagResolver` is invoked for each log if the explicit tag is null.

`AutomaticTagResolver` implements `() -> String` by crawling the stack trace for the appropriate class name. Its implementation is almost directly copied from the Timber 4 implementation. It includes a note in the KDocs that use in release builds is discouraged.

Happy to add tests and/or adjust the implementation/API if you accept the general premise of this PR.