### PR TITLE
Allow additional ignored classes when inferring tags in DebugTree

### DIFF
--- a/timber/src/main/java/timber/log/Timber.kt
+++ b/timber/src/main/java/timber/log/Timber.kt
@@ -194,7 +194,7 @@ class Timber private constructor() {
 
   /** A [Tree] for debug builds. Automatically infers the tag from the calling class. */
   open class DebugTree : Tree() {
-    private val fqcnIgnore = listOf(
+    private val fqcnIgnore = mutableSetOf(
         Timber::class.java.name,
         Timber.Forest::class.java.name,
         Tree::class.java.name,
@@ -205,6 +205,14 @@ class Timber private constructor() {
       get() = super.tag ?: Throwable().stackTrace
           .first { it.className !in fqcnIgnore }
           .let(::createStackElementTag)
+
+    /**
+     * Register an extra class name to be ignored when inferring the log tag from the
+     * stacktrace.
+     */
+    fun ignoreForTagging(ignoredClass: Class<out Any>) {
+      fqcnIgnore.add(ignoredClass.name)
+    }
 
     /**
      * Extract the tag which should be used for the message from the `element`. By default

--- a/timber/src/main/java/timber/log/Timber.kt
+++ b/timber/src/main/java/timber/log/Timber.kt
@@ -193,26 +193,18 @@ class Timber private constructor() {
   }
 
   /** A [Tree] for debug builds. Automatically infers the tag from the calling class. */
-  open class DebugTree : Tree() {
-    private val fqcnIgnore = mutableSetOf(
+  open class DebugTree(vararg ignoredClasses: Class<*>) : Tree() {
+    private val fqcnIgnore = setOf(
         Timber::class.java.name,
         Timber.Forest::class.java.name,
         Tree::class.java.name,
         DebugTree::class.java.name
-    )
+    ).plus(ignoredClasses.map { it.name })
 
     override val tag: String?
       get() = super.tag ?: Throwable().stackTrace
           .first { it.className !in fqcnIgnore }
           .let(::createStackElementTag)
-
-    /**
-     * Register an extra class name to be ignored when inferring the log tag from the
-     * stacktrace.
-     */
-    fun ignoreForTagging(ignoredClass: Class<out Any>) {
-      fqcnIgnore.add(ignoredClass.name)
-    }
 
     /**
      * Extract the tag which should be used for the message from the `element`. By default

--- a/timber/src/test/java/timber/log/TimberTest.kt
+++ b/timber/src/test/java/timber/log/TimberTest.kt
@@ -209,6 +209,18 @@ class TimberTest {
         .hasNoMoreMessages()
   }
 
+  @Test fun debugTreeDoesNotUseIgnoredClassForTag() {
+    val tree = Timber.DebugTree()
+    tree.ignoreForTagging(ThisIsAReallyLongClassName::class.java)
+    Timber.plant(tree)
+
+    ThisIsAReallyLongClassName().run()
+
+    assertLog()
+        .hasDebugMessage("TimberTest", "Hello, world!")
+        .hasNoMoreMessages()
+  }
+
   @Test fun debugTreeCustomTag() {
     Timber.plant(Timber.DebugTree())
     Timber.tag("Custom").d("Hello, world!")

--- a/timber/src/test/java/timber/log/TimberTest.kt
+++ b/timber/src/test/java/timber/log/TimberTest.kt
@@ -210,8 +210,7 @@ class TimberTest {
   }
 
   @Test fun debugTreeDoesNotUseIgnoredClassForTag() {
-    val tree = Timber.DebugTree()
-    tree.ignoreForTagging(ThisIsAReallyLongClassName::class.java)
+    val tree = Timber.DebugTree(ThisIsAReallyLongClassName::class.java)
     Timber.plant(tree)
 
     ThisIsAReallyLongClassName().run()


### PR DESCRIPTION
Fixes #180 on a per-Tree basis.
Replaces #314 given the new internal tag-determination logic.

Add `DebugTree#ignoreForTagging(Class)` to allow more classes to be ignored when the tag is inferred from the stacktrace. This is useful for anyone needing to wrap Timber, e.g. for use in a Java-only module.

Also changes `fqcnIgnore` from a list into a set because only its `contains` method is used.