### PR TITLE
Move to newer lintPublish API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
       'kotlin': '1.3.21',
 
-      'androidPlugin': '3.3.2',
+      'androidPlugin': '3.4.0',
       'androidTools': '26.3.2',
 
       'butterknife': '8.8.1',

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
       'kotlin': '1.3.21',
 
       'androidPlugin': '3.4.0',
-      'androidTools': '26.3.2',
+       'androidTools': '26.4.0',
 
       'butterknife': '8.8.1',
   ]

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
       'kotlin': '1.3.21',
 
       'androidPlugin': '3.4.0',
-       'androidTools': '26.4.0',
+      'androidTools': '26.4.0',
 
       'butterknife': '8.8.1',
   ]

--- a/timber-sample/build.gradle
+++ b/timber-sample/build.gradle
@@ -27,6 +27,4 @@ dependencies {
   implementation project(':timber')
   implementation deps.butterknife.runtime
   annotationProcessor deps.butterknife.compiler
-  
-  lintChecks project(':timber-lint')
 }

--- a/timber/build.gradle
+++ b/timber/build.gradle
@@ -30,7 +30,7 @@ dependencies {
   testImplementation deps.truth
   testImplementation deps.robolectric
 
-  lintChecks project(':timber-lint')
+  lintPublish project(':timber-lint')
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')


### PR DESCRIPTION
With AGP 3.4.0, libraries that publish their lint checks have to use the newer `lintPublish` API. 