### PR TITLE
Add Gradle plugin for transforming logcat to timber

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ buildscript {
           'checks': "com.android.tools.lint:lint-checks:${versions.androidTools}",
           'tests': "com.android.tools.lint:lint-tests:${versions.androidTools}",
       ],
+      asm: 'org.ow2.asm:asm:7.1',
       annotations: 'org.jetbrains:annotations:16.0.1',
 
       junit: 'junit:junit:4.12',

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -82,31 +82,48 @@ afterEvaluate { project ->
     sign configurations.archives
   }
 
-  task androidJavadocs(type: Javadoc) {
-    if (!project.plugins.hasPlugin('kotlin-android')) {
-      source = android.sourceSets.main.java.srcDirs
+  if (project.plugins.hasPlugin('com.android.library')) {
+    task androidJavadocs(type: Javadoc) {
+      if (!project.plugins.hasPlugin('kotlin-android')) {
+        source = android.sourceSets.main.java.srcDirs
+      }
+      classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+      exclude '**/internal/*'
+      include '**/*.java'
+
+      if (JavaVersion.current().isJava8Compatible()) {
+        options.addStringOption('Xdoclint:none', '-quiet')
+      }
     }
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    exclude '**/internal/*'
-    include '**/*.java'
 
-    if (JavaVersion.current().isJava8Compatible()) {
-      options.addStringOption('Xdoclint:none', '-quiet')
+    task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
+      classifier = 'javadoc'
+      from androidJavadocs.destinationDir
     }
-  }
 
-  task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
-    classifier = 'javadoc'
-    from androidJavadocs.destinationDir
-  }
+    task androidSourcesJar(type: Jar) {
+      classifier = 'sources'
+      from android.sourceSets.main.java.sourceFiles
+    }
 
-  task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.sourceFiles
-  }
+    artifacts {
+      archives androidSourcesJar
+      archives androidJavadocsJar
+    }
+  } else {
+    task sourcesJar(type: Jar, dependsOn: classes) {
+      classifier = 'sources'
+      from sourceSets.main.allSource
+    }
 
-  artifacts {
-    archives androidSourcesJar
-    archives androidJavadocsJar
+    task javadocJar(type: Jar, dependsOn: javadoc) {
+      classifier = 'javadoc'
+      from javadoc.destinationDir
+    }
+
+    artifacts {
+      archives sourcesJar
+      archives javadocJar
+    }
   }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 include ':timber'
 include ':timber:japicmp'
+include ':timber-gradle-plugin'
 include ':timber-lint'
 include ':timber-sample'
 

--- a/timber-gradle-plugin/build.gradle
+++ b/timber-gradle-plugin/build.gradle
@@ -1,0 +1,11 @@
+apply plugin: 'kotlin'
+
+dependencies {
+  compileOnly gradleApi()
+  compileOnly deps.androidPlugin
+
+  implementation deps.asm
+  implementation deps.kotlin.stdlib
+}
+
+apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/timber-gradle-plugin/gradle.properties
+++ b/timber-gradle-plugin/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=timber-gradle-plugin
+POM_NAME=Timber Gradle plugin
+POM_PACKAGING=jar

--- a/timber-gradle-plugin/src/main/java/timber/gradle/TimberExtension.kt
+++ b/timber-gradle-plugin/src/main/java/timber/gradle/TimberExtension.kt
@@ -1,0 +1,6 @@
+package timber.gradle
+
+open class TimberExtension {
+  var variantNameFilter: (String) -> Boolean = { true }
+  var classNameFilter: (String) -> Boolean = { true }
+}

--- a/timber-gradle-plugin/src/main/java/timber/gradle/TimberPlugin.kt
+++ b/timber-gradle-plugin/src/main/java/timber/gradle/TimberPlugin.kt
@@ -1,0 +1,24 @@
+package timber.gradle
+
+import com.android.build.gradle.AppPlugin
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import timber.gradle.transform.LogRewritingTransform
+
+fun isTimberClass(name: String) = name.startsWith("timber/")
+
+class TimberPlugin : Plugin<Project> {
+  override fun apply(project: Project) {
+    project.plugins.withId("com.android.application") { plugin ->
+      val extension = project.extensions.create("timber", TimberExtension::class.java)
+      val appPlugin = plugin as AppPlugin
+
+      val transform = LogRewritingTransform(
+          extension.variantNameFilter,
+          { name -> !isTimberClass(name) && extension.classNameFilter(name) }
+      )
+
+      appPlugin.extension.registerTransform(transform)
+    }
+  }
+}

--- a/timber-gradle-plugin/src/main/java/timber/gradle/transform/ClassRewriter.kt
+++ b/timber-gradle-plugin/src/main/java/timber/gradle/transform/ClassRewriter.kt
@@ -1,0 +1,12 @@
+package timber.gradle.transform
+
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+
+internal class ClassRewriter(cv: ClassVisitor): ClassVisitor(Opcodes.ASM7, cv) {
+  override fun visitMethod(access: Int, name: String, descriptor: String, signature: String?, exceptions: Array<out String>?): MethodVisitor {
+    val mv = super.visitMethod(access, name, descriptor, signature, exceptions)
+    return MethodRewriter(access, descriptor, mv)
+  }
+}

--- a/timber-gradle-plugin/src/main/java/timber/gradle/transform/LogRewritingTransform.kt
+++ b/timber-gradle-plugin/src/main/java/timber/gradle/transform/LogRewritingTransform.kt
@@ -1,0 +1,124 @@
+package timber.gradle.transform
+
+import com.android.build.api.transform.Format
+import com.android.build.api.transform.QualifiedContent
+import com.android.build.api.transform.Status
+import com.android.build.api.transform.Transform
+import com.android.build.api.transform.TransformInvocation
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassWriter
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
+
+class LogRewritingTransform(
+    private val variantNameFilter: (String) -> Boolean,
+    private val classNameFilter: (String) -> Boolean
+) : Transform() {
+  override fun getName() = "logcat-to-timber"
+  override fun getInputTypes() = setOf(QualifiedContent.DefaultContentType.CLASSES)
+  override fun isIncremental() = true
+  override fun getScopes() = mutableSetOf(QualifiedContent.Scope.EXTERNAL_LIBRARIES)
+
+  override fun transform(invoke: TransformInvocation) {
+    super.transform(invoke)
+
+    val incremental = invoke.isIncremental
+    val rewrite = variantNameFilter(invoke.context.variantName)
+
+    if (!incremental) {
+      invoke.outputProvider.deleteAll()
+    }
+
+    for (input in invoke.inputs) {
+      for (dirInput in input.directoryInputs) {
+
+        val output = invoke.outputProvider.getContentLocation(
+            "timbered-${dirInput.name}",
+            dirInput.contentTypes, dirInput.scopes,
+            Format.DIRECTORY)
+
+        val files = if (incremental) {
+          dirInput.changedFiles
+        } else {
+          dirInput.file.walk().filter { it.isFile }.map { it to Status.ADDED }.toMap()
+        }
+
+        files.forEach { (file, status) ->
+          val relative = file.toRelativeString(dirInput.file)
+          val target = output.resolve(relative)
+          when (status!!) {
+            Status.ADDED, Status.CHANGED -> {
+              processFile(file, target, rewrite)
+            }
+            Status.REMOVED -> {
+              target.delete()
+            }
+            Status.NOTCHANGED -> { /* do nothing */  }
+          }
+        }
+      }
+      for (jarInput in input.jarInputs) {
+        val target = invoke.outputProvider.getContentLocation("timbered-${jarInput.name}", jarInput.contentTypes, jarInput.scopes, Format.JAR)
+        val status = if (incremental) jarInput.status!! else Status.ADDED
+        when (status) {
+          Status.ADDED, Status.CHANGED -> {
+            processJar(jarInput.file, target, rewrite)
+          }
+          Status.REMOVED -> {
+            target.delete()
+          }
+          Status.NOTCHANGED -> { /* do nothing */ }
+        }
+      }
+    }
+  }
+
+  private fun processFile(input: File, output: File, rewrite: Boolean) {
+    output.parentFile.mkdirs()
+    if (rewrite) {
+      input.inputStream().use { inputStream ->
+        output.writeBytes(transformClass(inputStream.readBytes()))
+      }
+    } else {
+      input.copyTo(output, overwrite = true)
+    }
+  }
+
+  private fun processJar(input: File, output: File, rewrite: Boolean) {
+    output.parentFile.mkdirs()
+    if (rewrite) {
+      ZipInputStream(input.inputStream().buffered()).use { zipIn  ->
+        ZipOutputStream(output.outputStream().buffered()).use { zipOut ->
+          while (true) {
+            val entry = zipIn.nextEntry ?: break
+            val outEntry = ZipEntry(entry.name)
+            val inputBytes = zipIn.readBytes()
+            val processedBytes = if (entry.name.endsWith(".class")) {
+               transformClass(inputBytes)
+            } else {
+              inputBytes
+            }
+            outEntry.size = processedBytes.size.toLong()
+            zipOut.putNextEntry(outEntry)
+            zipOut.write(processedBytes)
+          }
+        }
+      }
+    } else {
+      input.copyTo(output, overwrite = true)
+    }
+  }
+
+  private fun transformClass(input: ByteArray): ByteArray {
+    val cr = ClassReader(input)
+    if (classNameFilter(cr.className)) {
+      val cw = ClassWriter(0)
+      cr.accept(ClassRewriter(cw), ClassReader.EXPAND_FRAMES)
+      return cw.toByteArray()
+    } else {
+      return input
+    }
+  }
+}

--- a/timber-gradle-plugin/src/main/java/timber/gradle/transform/MethodRewriter.kt
+++ b/timber-gradle-plugin/src/main/java/timber/gradle/transform/MethodRewriter.kt
@@ -1,0 +1,120 @@
+package timber.gradle.transform
+
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.Type
+import org.objectweb.asm.commons.LocalVariablesSorter
+
+private const val LOG_TYPE = "android/util/Log"
+private const val OBJECT_TYPE = "java/lang/Object"
+private const val STRING_TYPE = "java/lang/String"
+private const val THROWABLE_TYPE = "java/lang/Throwable"
+private const val TIMBER_TYPE = "timber/log/Timber"
+private const val TREE_TYPE = "timber/log/Timber\$Tree"
+
+private val TARGET_METHODS = setOf("d", "e", "i", "v", "w", "wtf")
+
+internal class MethodRewriter(access: Int, desc: String, mv: MethodVisitor) : LocalVariablesSorter(Opcodes.ASM7, access, desc, mv) {
+  override fun visitMethodInsn(opcode: Int, owner: String, name: String, descriptor: String, isInterface: Boolean) {
+    if (opcode == Opcodes.INVOKESTATIC && owner == LOG_TYPE) {
+      if (name in TARGET_METHODS) {
+        if (descriptor == "(L$STRING_TYPE;L$STRING_TYPE;L$THROWABLE_TYPE;)I") {
+          // Log.x(tag, msg, tr)
+          rewriteTagMsgThrowable(name)
+          return
+        } else if (descriptor == "(L$STRING_TYPE;L$STRING_TYPE;)I") {
+          // Log.x(tag, msg)
+          rewriteTagMsg(name)
+          return
+        } else if (name.startsWith("w") && descriptor == "(L$STRING_TYPE;L$THROWABLE_TYPE;)I") {
+          // Log.x(tag, tr)
+          rewriteTagThrowable(name)
+          return
+        }
+      } else if (name == "println" && descriptor == "(IL$STRING_TYPE;L$STRING_TYPE;)I") {
+        // Log.println(priority, tag, msg)
+        rewritePrintln()
+        return
+      }
+    }
+    super.visitMethodInsn(opcode, owner, name, descriptor, isInterface)
+  }
+
+  /**
+   * Rewrites `Log.$x(tag, msg)` into `Timber.tag(tag).$x(msg, new Object[0])`
+   */
+  private fun rewriteTagMsg(method: String) {
+    swap() // tag, msg -> msg, tag
+    invokeTag()
+    swap() // msg, tree -> tree, msg
+    emptyArray()
+    super.visitMethodInsn(Opcodes.INVOKEVIRTUAL, TREE_TYPE, method, "(L$STRING_TYPE;[L$OBJECT_TYPE;)V", false)
+    const0()
+  }
+
+  /**
+   * Rewrites `Log.$x(tag, msg, tr)` into `Timber.tag(tag).$x(tr, msg, new Object[0])`
+   */
+  private fun rewriteTagMsgThrowable(method: String) {
+    val slot = store(THROWABLE_TYPE)
+    swap() // tag, msg -> msg, tag
+    invokeTag()
+    swap() // msg, tree -> tree, msg
+    load(slot)
+    swap() // msg, throwable -> throwable, msg
+    emptyArray()
+    super.visitMethodInsn(Opcodes.INVOKEVIRTUAL, TREE_TYPE, method, "(L$THROWABLE_TYPE;L$STRING_TYPE;[L$OBJECT_TYPE;)V", false)
+    const0()
+  }
+
+  /**
+   * Rewrites `Log.$x(tag, tr)` into `Timber.tag(tag).x(tr)`
+   */
+  private fun rewriteTagThrowable(method: String) {
+    swap() // tag, tr -> tr, tag
+    invokeTag()
+    swap() // tr, tree -> tree, tr
+    super.visitMethodInsn(Opcodes.INVOKEVIRTUAL, TREE_TYPE, method, "(L$THROWABLE_TYPE;)V", false)
+    const0()
+  }
+
+  /**
+   * Rewrites `Log.println(priority, tag, msg)` to `Timber.tag(tag).log(priority, msg, new Object[0])`
+   */
+  private fun rewritePrintln() {
+    val slot = store(STRING_TYPE)
+    invokeTag()
+    swap() // priority, tree -> tree, priority
+    load(slot)
+    emptyArray()
+    super.visitMethodInsn(Opcodes.INVOKEVIRTUAL, TREE_TYPE, "log", "(IL$STRING_TYPE;[L$OBJECT_TYPE;)V", false)
+    const0()
+  }
+
+  private fun swap() {
+    super.visitInsn(Opcodes.SWAP)
+  }
+
+  private fun invokeTag() {
+    super.visitMethodInsn(Opcodes.INVOKESTATIC, TIMBER_TYPE, "tag", "(L$STRING_TYPE;)L$TREE_TYPE;", false)
+  }
+
+  private fun emptyArray() {
+    super.visitInsn(Opcodes.ICONST_0)
+    super.visitTypeInsn(Opcodes.ANEWARRAY, OBJECT_TYPE)
+  }
+
+  private fun const0() {
+    super.visitInsn(Opcodes.ICONST_0)
+  }
+
+  private fun store(type: String): Int {
+    val slot = newLocal(Type.getObjectType(type))
+    super.visitVarInsn(Opcodes.ASTORE, slot)
+    return slot
+  }
+
+  private fun load(slot: Int) {
+    super.visitVarInsn(Opcodes.ALOAD, slot)
+  }
+}

--- a/timber-gradle-plugin/src/main/resources/META-INF/gradle-plugins/timber.properties
+++ b/timber-gradle-plugin/src/main/resources/META-INF/gradle-plugins/timber.properties
@@ -1,0 +1,1 @@
+implementation-class=timber.gradle.TimberPlugin


### PR DESCRIPTION
This commit adds a Gradle plugin that enables one to rewrite `Log.x` calls into `Timber.x` calls in any upstream libraries.

There's some basic configuration options available via a `timber {}` extension:

```
configure<TimberExtension> {
  variantNameFilter = { it == "debug" }
  classNameFilter = { !it.startsWith("com/foobar/log") }
}
```

The re-written implementation at callsites isn't very performant so I wouldn't recommend to use it in production.