### PR TITLE
enable logging by delegation

### DIFF
--- a/timber/src/main/java/timber/log/Timber.kt
+++ b/timber/src/main/java/timber/log/Timber.kt
@@ -193,13 +193,18 @@ class Timber private constructor() {
   }
 
   /** A [Tree] for debug builds. Automatically infers the tag from the calling class. */
-  open class DebugTree : Tree() {
-    private val fqcnIgnore = listOf(
-        Timber::class.java.name,
-        Timber.Forest::class.java.name,
-        Tree::class.java.name,
-        DebugTree::class.java.name
-    )
+  open class DebugTree(delegator: Class<*>? = null) : Tree() {
+
+    private val fqcnIgnore : MutableList<String> = listOf(
+      Timber::class.java.name,
+      Timber.Forest::class.java.name,
+      Tree::class.java.name,
+      DebugTree::class.java.name
+    ).toMutableList()
+
+    init {
+      delegator?.let { fqcnIgnore.add(it.name) }
+    }
 
     override val tag: String?
       get() = super.tag ?: Throwable().stackTrace


### PR DESCRIPTION
When you have to use Timber with a delegator, currently you log just the delegator class. -sad-
Or when you change logging tool just in one place and do not change every log call in code (this can be very easy > 1000 places), you probably need a delegator.

With this PR you can solve this (in my point of view) elegant