### PR TITLE
Added the HyperlinkedDebugTree class that creates Logs that include hyperlinks to the calling line

### DIFF
--- a/timber/src/main/java/timber/log/Timber.kt
+++ b/timber/src/main/java/timber/log/Timber.kt
@@ -5,8 +5,7 @@ import android.util.Log
 import org.jetbrains.annotations.NonNls
 import java.io.PrintWriter
 import java.io.StringWriter
-import java.util.ArrayList
-import java.util.Collections
+import java.util.*
 import java.util.Collections.unmodifiableList
 import java.util.regex.Pattern
 
@@ -269,6 +268,17 @@ class Timber private constructor() {
       private const val MAX_TAG_LENGTH = 23
       private val ANONYMOUS_CLASS = Pattern.compile("(\\$\\d+)+$")
     }
+  }
+
+  /**
+   * A [Tree] for debug builds.
+   * Automatically shows a Hyperlink to the calling Class and Linenumber in the Logs.
+   * Allows quick lookup of the caller source just by clicking on the Hyperlink in the Log.
+   * @param showMethodName Whether or not to show the method name as well
+   */
+  class HyperlinkedDebugTree(private val showMethodName: Boolean = true) : DebugTree() {
+    override fun createStackElementTag(element: StackTraceElement) =
+            with(element) { "($fileName:$lineNumber) ${if (showMethodName) " $methodName()" else ""}" }
   }
 
   companion object Forest : Tree() {

--- a/timber/src/main/java/timber/log/Timber.kt
+++ b/timber/src/main/java/timber/log/Timber.kt
@@ -5,7 +5,8 @@ import android.util.Log
 import org.jetbrains.annotations.NonNls
 import java.io.PrintWriter
 import java.io.StringWriter
-import java.util.*
+import java.util.ArrayList
+import java.util.Collections
 import java.util.Collections.unmodifiableList
 import java.util.regex.Pattern
 


### PR DESCRIPTION
Added the HyperlinkedDebugTree class that creates Logs that include hyperlinks to the calling line

This way you can just click on the Tag and directly jump to the source. Very useful in big projects.

I think this should be included in some form as otherwise people who use the library won't know that this is even a possibility. I certainly didn't :D
The class also has a boolean variable that controls whether or not to show the method name too.

So planting it either looks like this:
`Timber.plant(HyperlinkedDebugTree(false))`
Or (because it's default value is true):
`Timber.plant(HyperlinkedDebugTree())`

This then looks similar to this (with clickable Hyperlinks)
`D/`[(AddItemFragment.kt:222)](https://www.reddit.com/r/mAndroidDev/comments/dxtzc6/he_is_the_messiah/)`getImageCaptureUri(): logMessage`

`D/`[(AddItemFragment.kt:222)](https://www.reddit.com/r/mAndroidDev/comments/dxtzc6/he_is_the_messiah/)`: logMessage`
(there is no space before the ":", only here because I had to mark it as a link)

If you want to merge this PR but I forgot something like Testing or perhaps stuff like adding it in the Changelog, tell me.

At some point this might even be useful in the Readme file🗡  