### PR TITLE
feat: adding an attach stacktrace option

### DIFF
--- a/timber-sample/src/main/java/com/example/timber/ExampleApp.java
+++ b/timber-sample/src/main/java/com/example/timber/ExampleApp.java
@@ -21,9 +21,6 @@ public class ExampleApp extends Application {
   /** A tree which logs important information for crash reporting. */
   private static class CrashReportingTree extends Timber.Tree {
     CrashReportingTree() {
-      // attachStackTraceString=false
-      // usually crash reporting tools already gets stack traces in a structured way,
-      // because they might need to be demangled.
       super(false);
     }
 

--- a/timber-sample/src/main/java/com/example/timber/ExampleApp.java
+++ b/timber-sample/src/main/java/com/example/timber/ExampleApp.java
@@ -20,6 +20,13 @@ public class ExampleApp extends Application {
 
   /** A tree which logs important information for crash reporting. */
   private static class CrashReportingTree extends Timber.Tree {
+    CrashReportingTree() {
+      // attachStackTraceString=false
+      // usually crash reporting tools already gets stack traces in a structured way,
+      // because they might need to be demangled.
+      super(false);
+    }
+
     @Override protected void log(int priority, String tag, @NonNull String message, Throwable t) {
       if (priority == Log.VERBOSE || priority == Log.DEBUG) {
         return;

--- a/timber/src/main/java/timber/log/Timber.kt
+++ b/timber/src/main/java/timber/log/Timber.kt
@@ -17,7 +17,7 @@ class Timber private constructor() {
   }
 
   /** A facade for handling logging calls. Install instances via [`Timber.plant()`][.plant]. */
-  abstract class Tree {
+  abstract class Tree(private val attachStackTraceString: Boolean = true) {
     @get:JvmSynthetic // Hide from public API.
     internal val explicitTag = ThreadLocal<String>()
 
@@ -155,12 +155,12 @@ class Timber private constructor() {
         if (t == null) {
           return  // Swallow message if it's null and there's no throwable.
         }
-        message = getStackTraceString(t)
+        message = if (attachStackTraceString) getStackTraceString(t) else ""
       } else {
         if (args.isNotEmpty()) {
           message = formatMessage(message, args)
         }
-        if (t != null) {
+        if (t != null && attachStackTraceString) {
           message += "\n" + getStackTraceString(t)
         }
       }


### PR DESCRIPTION
hey, it'd be nice to have an attach stack trace option so you can opt-out of concatenating user's message and stack traces.

it's enabled by default, so no breaking changes here.

Usually, crash reporting tools already get stack traces in a structured way because they might need to be demangled.

What do you think? this is just a draft, but I'm willing to work on it and add tests etc...

Thanks for the great work!