### PR TITLE
Update jetbrains-annotations dependency to current

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ buildscript {
           'checks': "com.android.tools.lint:lint-checks:${versions.androidTools}",
           'tests': "com.android.tools.lint:lint-tests:${versions.androidTools}",
       ],
-      annotations: 'org.jetbrains:annotations:16.0.1',
+      annotations: 'org.jetbrains:annotations:19.0.0',
 
       junit: 'junit:junit:4.12',
       truth: 'com.google.truth:truth:0.41',


### PR DESCRIPTION
Hey @JakeWharton looks like the Timber repo is pretty static, but this is a quick jetbrains-annotations dependency bump that passes `./gradlew clean test` in my fork anyway

I suppose if nothing merges + releases here I can just exclude jetbrains-annotations from my timber dep so it doesn't transitively constrain me from updating the dep since it appears to work fine

Cheers

Fixes #391