### PR TITLE
Supporting custome locales for logging

### DIFF
--- a/timber/src/main/java/timber/log/Timber.kt
+++ b/timber/src/main/java/timber/log/Timber.kt
@@ -8,6 +8,7 @@ import java.io.StringWriter
 import java.util.ArrayList
 import java.util.Collections
 import java.util.Collections.unmodifiableList
+import java.util.Locale
 import java.util.regex.Pattern
 
 /** Logging for lazy people. */
@@ -169,7 +170,13 @@ class Timber private constructor() {
     }
 
     /** Formats a log message with optional arguments. */
-    protected open fun formatMessage(message: String, args: Array<out Any?>) = message.format(*args)
+    protected open fun formatMessage(message: String, args: Array<out Any?>): String {
+      if (locale == null) {
+        return message.format(*args)
+      }
+
+      return message.format(locale!!, *args)
+    }
 
     private fun getStackTraceString(t: Throwable): String {
       // Don't replace this with Log.getStackTraceString() - it hides
@@ -447,6 +454,10 @@ class Timber private constructor() {
 
     @get:[JvmStatic JvmName("treeCount")]
     val treeCount get() = treeArray.size
+
+    @get:JvmSynthetic
+    @set:[JvmStatic JvmName("setLocale")]
+    open var locale: Locale? = null
 
     // Both fields guarded by 'trees'.
     private val trees = ArrayList<Tree>()

--- a/timber/src/test/java/timber/log/TimberTest.kt
+++ b/timber/src/test/java/timber/log/TimberTest.kt
@@ -7,6 +7,7 @@ import java.net.ConnectException
 import java.net.UnknownHostException
 import java.util.ArrayList
 import java.util.concurrent.CountDownLatch
+import java.util.Locale
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -304,6 +305,36 @@ class TimberTest {
         .hasDebugMessage("TimberTest", 'b'.repeat(2000))
         .hasDebugMessage("TimberTest", 'c'.repeat(3000))
         .hasNoMoreMessages()
+  }
+
+  @Test fun logMessageWithDefaultLocale() {
+    val defaultLocale = Locale.getDefault()
+
+    Locale.setDefault(Locale.US)
+    Timber.d("There is %d %s", 1, "tree")
+
+    Locale.setDefault(Locale("ar"))
+    Timber.d("There are %d %s", 2, "trees")
+
+    Locale.setDefault(defaultLocale)
+
+    assertLog()
+      .hasDebugMessage("TimberTest", "There is 1 tree")
+      .hasDebugMessage("TimberTest", "There are 2 trees")
+      .hasNoMoreMessages()
+  }
+
+  @Test fun logMessageWithCustomLocale() {
+    Timber.setLocale(Locale.US)
+    Timber.d("There is %d %s", 1, "tree")
+
+    Timber.setLocale(Locale("ar"))
+    Timber.d("There are %d %s", 2, "trees")
+
+    assertLog()
+      .hasDebugMessage("TimberTest", "There is 1 tree")
+      .hasDebugMessage("TimberTest", "There are 2 trees")
+      .hasNoMoreMessages()
   }
 
   @Test fun nullMessageWithoutThrowable() {


### PR DESCRIPTION
I'm having a hard time with logs getting affected by the user's locales. Numbers are the main problem as "%d" can end up using another numerical notation, like Arabic numbers. 

`10` == `١٠`

After putting some thought I went with the option to set a custom locale for `Timber`, as most of the static implementations are already affecting the whole forest.

If no locale is set it behaves as it used to.

```kotlin
Timber.setLocale(Locale.US)
Timber.setLocale(Locale("ar"))
```

Note: Creating the PR as a draft as I'm having a hard time running the tests. I have tested the implementation manually and dropped some test ideas that I still need to properly code. Let me know if you find this approach interesting.

Cheers,
Roberto