### PR TITLE
Tag length limit was removed in API 26 not API 24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Version 4.6.0 *(2017-10-30)*
 
  * New: Lint checks have been ported to UAST, their stability improved, and quick-fix suggestions added. They require Android Gradle Plugin 3.0 or newer to run.
  * New: Added nullability annotations for Kotlin users.
- * Fix: Tag length truncation no longer occurs on API ~24~ 26 or newer as the system no longer has a length restriction.
+ * Fix: Tag length truncation no longer occurs on API 24 or newer as the system no longer has a length restriction.
  * Fix: Handle when a `null` array is supplied for the message arguments. This can occur when using various bytecode optimization tools.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Version 4.6.0 *(2017-10-30)*
 
  * New: Lint checks have been ported to UAST, their stability improved, and quick-fix suggestions added. They require Android Gradle Plugin 3.0 or newer to run.
  * New: Added nullability annotations for Kotlin users.
- * Fix: Tag length truncation no longer occurs on API 24 or newer as the system no longer has a length restriction.
+ * Fix: Tag length truncation no longer occurs on API ~24~ 26 or newer as the system no longer has a length restriction.
  * Fix: Handle when a `null` array is supplied for the message arguments. This can occur when using various bytecode optimization tools.
 
 

--- a/timber/src/main/java/timber/log/Timber.kt
+++ b/timber/src/main/java/timber/log/Timber.kt
@@ -219,8 +219,8 @@ class Timber private constructor() {
       if (m.find()) {
         tag = m.replaceAll("")
       }
-      // Tag length limit was removed in API 24.
-      return if (tag.length <= MAX_TAG_LENGTH || Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      // Tag length limit was removed in API 26.
+      return if (tag.length <= MAX_TAG_LENGTH || Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         tag
       } else {
         tag.substring(0, MAX_TAG_LENGTH)

--- a/timber/src/main/java/timber/log/Timber.kt
+++ b/timber/src/main/java/timber/log/Timber.kt
@@ -220,7 +220,7 @@ class Timber private constructor() {
         tag = m.replaceAll("")
       }
       // Tag length limit was removed in API 26.
-      return if (tag.length <= MAX_TAG_LENGTH || Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      return if (tag.length <= MAX_TAG_LENGTH || Build.VERSION.SDK_INT >= 26) {
         tag
       } else {
         tag.substring(0, MAX_TAG_LENGTH)

--- a/timber/src/test/java/timber/log/TimberTest.kt
+++ b/timber/src/test/java/timber/log/TimberTest.kt
@@ -144,7 +144,7 @@ class TimberTest {
     }
   }
 
-  @Config(sdk = [23])
+  @Config(sdk = [25])
   @Test fun debugTreeTagTruncation() {
     Timber.plant(Timber.DebugTree())
 
@@ -155,7 +155,7 @@ class TimberTest {
         .hasNoMoreMessages()
   }
 
-  @Config(sdk = [24])
+  @Config(sdk = [26])
   @Test fun debugTreeTagNoTruncation() {
     Timber.plant(Timber.DebugTree())
 


### PR DESCRIPTION
  - https://issuetracker.google.com/issues/124593220

The lint check is fixed by https://github.com/JakeWharton/timber/pull/421/