### PR TITLE
Fix Lint fallthrough errors

### DIFF
--- a/timber-lint/src/main/java/timber/lint/TimberIssueRegistry.kt
+++ b/timber-lint/src/main/java/timber/lint/TimberIssueRegistry.kt
@@ -10,7 +10,7 @@ import com.google.auto.service.AutoService
 @AutoService(value = [IssueRegistry::class])
 class TimberIssueRegistry : IssueRegistry() {
   override val issues: List<Issue>
-    get() = WrongTimberUsageDetector.issues
+    get() = WrongTimberUsageDetector.issues.asList()
 
   override val api: Int
     get() = CURRENT_API

--- a/timber-lint/src/main/java/timber/lint/WrongTimberUsageDetector.kt
+++ b/timber-lint/src/main/java/timber/lint/WrongTimberUsageDetector.kt
@@ -803,7 +803,7 @@ class WrongTimberUsageDetector : Detector(), UastScanner {
       implementation = Implementation(WrongTimberUsageDetector::class.java, JAVA_FILE_SCOPE)
     )
 
-    val issues = listOf(
+    val issues = arrayOf(
       ISSUE_LOG, ISSUE_FORMAT, ISSUE_THROWABLE, ISSUE_BINARY, ISSUE_ARG_COUNT, ISSUE_ARG_TYPES,
       ISSUE_TAG_LENGTH, ISSUE_EXCEPTION_LOGGING
     )

--- a/timber-lint/src/main/java/timber/lint/WrongTimberUsageDetector.kt
+++ b/timber-lint/src/main/java/timber/lint/WrongTimberUsageDetector.kt
@@ -81,13 +81,8 @@ class WrongTimberUsageDetector : Detector(), UastScanner {
       checkNestedStringFormat(context, node)
       return
     }
-    // As of API 26, Log tags are no longer limited to 23 chars.
-    if ("tag" == methodName
-      && evaluator.isMemberInClass(method, "timber.log.Timber")
-      && context.project.minSdk < 26
-    ) {
-      checkTagLength(context, node)
-      return
+    if ("tag" == methodName && evaluator.isMemberInClass(method, "timber.log.Timber")) {
+      checkTagLengthIfMinSdkLessThan26(context, node)
     }
     if (evaluator.isMemberInClass(method, "android.util.Log")) {
       context.report(
@@ -144,7 +139,7 @@ class WrongTimberUsageDetector : Detector(), UastScanner {
     }
   }
 
-  private fun checkTagLength(context: JavaContext, call: UCallExpression) {
+  private fun checkTagLengthIfMinSdkLessThan26(context: JavaContext, call: UCallExpression) {
     val argument = call.valueArguments[0]
     val tag = evaluateString(context, argument, true)
     if (tag != null && tag.length > 23) {
@@ -156,6 +151,7 @@ class WrongTimberUsageDetector : Detector(), UastScanner {
           message = "The logging tag can be at most 23 characters, was ${tag.length} ($tag)",
           fix = quickFixIssueTagLength(argument, tag)
         ),
+        // As of API 26, Log tags are no longer limited to 23 chars.
         constraint = minSdkLessThan(26)
       )
     }
@@ -178,7 +174,7 @@ class WrongTimberUsageDetector : Detector(), UastScanner {
       startIndexOfArguments++
     }
 
-    val formatString = evaluateString(context, formatStringArg, true)
+    val formatString = evaluateString(context, formatStringArg, false)
       ?: return // We passed for example a method call
 
     val formatArgumentCount = getFormatArgumentCount(formatString)

--- a/timber-lint/src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt
+++ b/timber-lint/src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt
@@ -435,6 +435,33 @@ class WrongTimberUsageDetectorTest {
         .expectClean()
   }
 
+  @Test fun validStringFormatExtracted() {
+    lint()
+      .files(TIMBER_STUB,
+          java("""
+              |package foo;
+              |import timber.log.Timber;
+              |public class Example {
+              |  public void log() {
+              |    String message = String.format("%s", "foo");
+              |    Timber.d(message);
+              |  }
+              |}""".trimMargin()),
+          kotlin("""
+              |package foo
+              |import timber.log.Timber
+              |class Example {
+              |  fun log() {
+              |    val message = String.format("%s", "foo")
+              |    Timber.d(message)
+              |  }
+              |}""".trimMargin()),
+      )
+      .issues(*issues)
+      .run()
+      .expectClean()
+  }
+
   @Test fun throwableNotAtBeginning() {
     lint()
         .files(TIMBER_STUB,
@@ -774,38 +801,6 @@ class WrongTimberUsageDetectorTest {
             |1 errors, 0 warnings""".trimMargin())
   }
 
-  @Test fun tagTooLongLiteralPlusField() {
-    lint()
-        .files(TIMBER_STUB,
-            java("""
-                |package foo;
-                |import timber.log.Timber;
-                |public class Example {
-                |  private final String field = "x";
-                |  public void log() {
-                |     Timber.tag("abcdefghijklmnopqrstuvw" + field);
-                |  }
-                |}""".trimMargin()),
-          kotlin("""
-                |package foo
-                |import timber.log.Timber
-                |class Example {
-                |  private val field = "x"
-                |  fun log() {
-                |     Timber.tag("abcdefghijklmnopqrstuvw${"$"}field")
-                |  }
-                |}""".trimMargin()),
-                manifest().minSdk(25)
-        )
-        .issues(*issues)
-        .run()
-        .expect("""
-            |src/foo/Example.java:6: Error: The logging tag can be at most 23 characters, was 24 (abcdefghijklmnopqrstuvwx) [TimberTagLength]
-            |     Timber.tag("abcdefghijklmnopqrstuvw" + field);
-            |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            |1 errors, 0 warnings""".trimMargin())
-  }
-
   @Test fun tagTooLongLiteralOnlyBeforeApi26() {
     lint()
         .files(TIMBER_STUB,
@@ -831,34 +826,6 @@ class WrongTimberUsageDetectorTest {
         .run()
         .expectClean()
   }
-
-  @Test fun tagTooLongLiteralPlusFieldOnlyBeforeApi26() {
-        lint()
-            .files(TIMBER_STUB,
-                java("""
-                    |package foo;
-                    |import timber.log.Timber;
-                    |public class Example {
-                    |  private final String field = "x";
-                    |  public void log() {
-                    |     Timber.tag("abcdefghijklmnopqrstuvw" + field);
-                    |  }
-                    |}""".trimMargin()),
-                kotlin("""
-                    |package foo
-                    |import timber.log.Timber
-                    |class Example {
-                    |  private val field = "x"
-                    |  fun log() {
-                    |     Timber.tag("abcdefghijklmnopqrstuvw${"$"}field")
-                    |  }
-                    |}""".trimMargin()),
-                    manifest().minSdk(26)
-                )
-                .issues(*issues)
-                .run()
-                .expectClean()
-    }
 
   @Test fun tooManyFormatArgsInTag() {
     lint()

--- a/timber-lint/src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt
+++ b/timber-lint/src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt
@@ -5,6 +5,7 @@ import com.android.tools.lint.checks.infrastructure.TestFiles.kotlin
 import com.android.tools.lint.checks.infrastructure.TestFiles.manifest
 import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
 import org.junit.Test
+import timber.lint.WrongTimberUsageDetector.Companion.issues
 
 class WrongTimberUsageDetectorTest {
   private val TIMBER_STUB = kotlin("""
@@ -41,7 +42,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_LOG)
+        .issues(*issues)
         .run()
         .expect("""
             |src/foo/Example.java:5: Warning: Using 'Log' instead of 'Timber' [LogNotTimber]
@@ -91,7 +92,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_LOG)
+        .issues(*issues)
         .run()
         .expect("""
             |src/foo/Example.java:5: Warning: Using 'Log' instead of 'Timber' [LogNotTimber]
@@ -139,7 +140,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_LOG)
+        .issues(*issues)
         .run()
         .expect("""
             |src/foo/Example.java:4: Warning: Using 'Log' instead of 'Timber' [LogNotTimber]
@@ -187,7 +188,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_LOG)
+        .issues(*issues)
         .run()
         .expect("""
             |src/foo/Example.java:4: Warning: Using 'Log' instead of 'Timber' [LogNotTimber]
@@ -237,7 +238,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_FORMAT)
+        .issues(*issues)
         .run()
         .expect("""
             |src/foo/Example.java:5: Warning: Using 'String#format' inside of 'Timber' [StringFormatInTimber]
@@ -284,7 +285,7 @@ class WrongTimberUsageDetectorTest {
         // Remove when AGP 7.1.0-alpha07 is out
         // https://groups.google.com/g/lint-dev/c/BigCO8sMhKU
         .allowCompilationErrors()
-        .issues(WrongTimberUsageDetector.ISSUE_FORMAT)
+        .issues(*issues)
         .run()
         .expect("""
             |src/foo/Example.java:6: Warning: Using 'String#format' inside of 'Timber' [StringFormatInTimber]
@@ -328,7 +329,7 @@ class WrongTimberUsageDetectorTest {
                 |  private fun id(s: String): String { return s }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_FORMAT)
+        .issues(*issues)
         .run()
         .expect("""
             |src/foo/Example.java:5: Warning: Using 'String#format' inside of 'Timber' [StringFormatInTimber]
@@ -354,7 +355,7 @@ class WrongTimberUsageDetectorTest {
                 |}""".trimMargin())
           // no kotlin equivalent, since nested assignments do not exist
         )
-        .issues(WrongTimberUsageDetector.ISSUE_FORMAT)
+        .issues(*issues)
         .run()
         .expect("""
             |src/foo/Example.java:6: Warning: Using 'String#format' inside of 'Timber' [StringFormatInTimber]
@@ -385,7 +386,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_FORMAT)
+        .issues(*issues)
         .run()
         .expectClean()
   }
@@ -408,7 +409,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_FORMAT)
+        .issues(*issues)
         .run()
         .expectClean()
   }
@@ -429,7 +430,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_FORMAT)
+        .issues(*issues)
         .run()
         .expectClean()
   }
@@ -456,7 +457,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_THROWABLE)
+        .issues(*issues)
         .run()
         .expect("""
             |src/foo/Example.java:6: Warning: Throwable should be first argument [ThrowableNotAtBeginning]
@@ -498,7 +499,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_BINARY)
+        .issues(*issues)
         .run()
         .expectClean()
   }
@@ -525,7 +526,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_BINARY)
+        .issues(*issues)
         .run()
         .expect("""
             |src/foo/Example.java:6: Warning: Replace String concatenation with Timber's string formatting [BinaryOperationInTimber]
@@ -562,7 +563,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_BINARY)
+        .issues(*issues)
         .run()
         .expect("""
             |src/foo/Example.java:6: Warning: Replace String concatenation with Timber's string formatting [BinaryOperationInTimber]
@@ -601,7 +602,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_BINARY)
+        .issues(*issues)
         .run()
         .expect("""
             |src/foo/Example.java:7: Warning: Replace String concatenation with Timber's string formatting [BinaryOperationInTimber]
@@ -638,7 +639,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_BINARY)
+        .issues(*issues)
         .run()
         .expect("""
             |src/foo/Example.java:6: Warning: Replace String concatenation with Timber's string formatting [BinaryOperationInTimber]
@@ -667,7 +668,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_ARG_COUNT)
+        .issues(*issues)
         .run()
         .expect("""
             |src/foo/Example.java:5: Error: Wrong argument count, format string %s %s requires 2 but format call supplies 1 [TimberArgCount]
@@ -699,7 +700,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_ARG_COUNT)
+        .issues(*issues)
         .run()
         .expect("""
             |src/foo/Example.java:5: Error: Wrong argument count, format string %s requires 1 but format call supplies 2 [TimberArgCount]
@@ -731,7 +732,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_ARG_TYPES)
+        .issues(*issues)
         .run()
         .expect("""
             |src/foo/Example.java:5: Error: Wrong argument type for formatting argument '#1' in %d: conversion is 'd', received String (argument #2 in method call) [TimberArgTypes]
@@ -764,7 +765,7 @@ class WrongTimberUsageDetectorTest {
                 |}""".trimMargin()),
                 manifest().minSdk(25)
         )
-        .issues(WrongTimberUsageDetector.ISSUE_TAG_LENGTH)
+        .issues(*issues)
         .run()
         .expect("""
             |src/foo/Example.java:5: Error: The logging tag can be at most 23 characters, was 24 (abcdefghijklmnopqrstuvwx) [TimberTagLength]
@@ -796,7 +797,7 @@ class WrongTimberUsageDetectorTest {
                 |}""".trimMargin()),
                 manifest().minSdk(25)
         )
-        .issues(WrongTimberUsageDetector.ISSUE_TAG_LENGTH)
+        .issues(*issues)
         .run()
         .expect("""
             |src/foo/Example.java:6: Error: The logging tag can be at most 23 characters, was 24 (abcdefghijklmnopqrstuvwx) [TimberTagLength]
@@ -826,7 +827,7 @@ class WrongTimberUsageDetectorTest {
                 |}""".trimMargin()),
             manifest().minSdk(26)
         )
-        .issues(WrongTimberUsageDetector.ISSUE_TAG_LENGTH)
+        .issues(*issues)
         .run()
         .expectClean()
   }
@@ -854,7 +855,7 @@ class WrongTimberUsageDetectorTest {
                     |}""".trimMargin()),
                     manifest().minSdk(26)
                 )
-                .issues(WrongTimberUsageDetector.ISSUE_TAG_LENGTH)
+                .issues(*issues)
                 .run()
                 .expectClean()
     }
@@ -879,7 +880,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_ARG_COUNT)
+        .issues(*issues)
         .run()
         .expect("""
             |src/foo/Example.java:5: Error: Wrong argument count, format string %s %s requires 2 but format call supplies 1 [TimberArgCount]
@@ -911,7 +912,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_ARG_COUNT)
+        .issues(*issues)
         .run()
         .expect("""
             |src/foo/Example.java:5: Error: Wrong argument count, format string %s requires 1 but format call supplies 2 [TimberArgCount]
@@ -943,7 +944,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_ARG_TYPES)
+        .issues(*issues)
         .run()
         .expect("""
             |src/foo/Example.java:5: Error: Wrong argument type for formatting argument '#1' in %d: conversion is 'd', received String (argument #2 in method call) [TimberArgTypes]
@@ -977,7 +978,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_EXCEPTION_LOGGING)
+        .issues(*issues)
         .run()
         .expect("""
             |src/foo/Example.java:6: Warning: Explicitly logging exception message is redundant [TimberExceptionLogging]
@@ -1021,7 +1022,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_EXCEPTION_LOGGING)
+        .issues(*issues)
         .run()
         .expect("""
             |src/foo/Example.java:6: Warning: Explicitly logging exception message is redundant [TimberExceptionLogging]
@@ -1067,7 +1068,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_EXCEPTION_LOGGING)
+        .issues(*issues)
         .run()
         .expectClean()
   }
@@ -1092,7 +1093,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_EXCEPTION_LOGGING)
+        .issues(*issues)
         .run()
         .expectClean()
   }
@@ -1123,7 +1124,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_EXCEPTION_LOGGING)
+        .issues(*issues)
         .run()
         .expectClean()
   }
@@ -1152,7 +1153,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_EXCEPTION_LOGGING)
+        .issues(*issues)
         .run()
         .expectClean()
   }
@@ -1181,7 +1182,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_EXCEPTION_LOGGING)
+        .issues(*issues)
         .run()
         .expectClean()
   }
@@ -1208,7 +1209,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_EXCEPTION_LOGGING)
+        .issues(*issues)
         .run()
         .expect("""
             |src/foo/Example.java:6: Warning: Use single-argument log method instead of null/empty message [TimberExceptionLogging]
@@ -1252,7 +1253,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_EXCEPTION_LOGGING)
+        .issues(*issues)
         .run()
         .expect("""
             |src/foo/Example.java:6: Warning: Use single-argument log method instead of null/empty message [TimberExceptionLogging]
@@ -1296,7 +1297,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_EXCEPTION_LOGGING)
+        .issues(*issues)
         .run()
         .expectClean()
   }
@@ -1321,7 +1322,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_ARG_TYPES)
+        .issues(*issues)
         .run()
         .expectClean()
   }
@@ -1346,7 +1347,7 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}""".trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_ARG_TYPES)
+        .issues(*issues)
         .run()
         .expectClean()
   }
@@ -1364,7 +1365,7 @@ class WrongTimberUsageDetectorTest {
                 |}""".trimMargin()),
             // no kotlin equivalent, since primitive wrappers do not exist
         )
-        .issues(WrongTimberUsageDetector.ISSUE_ARG_TYPES)
+        .issues(*issues)
         .run()
         .expectClean()
   }
@@ -1399,7 +1400,7 @@ class WrongTimberUsageDetectorTest {
                 |}
                 """.trimMargin())
         )
-        .issues(WrongTimberUsageDetector.ISSUE_EXCEPTION_LOGGING)
+        .issues(*issues)
         .run()
         .expectClean()
   }


### PR DESCRIPTION
Updated tests to run against all issues.  Why?

Fix 1: Investigating #434 highlighted a case where a potential ISSUE_FORMAT failure was being reported as a ISSUE_ARG_COUNT error.

The reason?  ConstantEvaluator.evaluateString(allowUnknown = true) results in "message" being evaluated to "%s" in the following test source:
```
  val message = String.format("%s", "foo")
  Timber.d(message)
```
which is incorrect, because then the Lint sees `Timber.d(message)` as `Timber.d("%s")`, which prompts the ISSUE_ARG_COUNT error.

Instead, by setting allowUnknowns = false, we force evaluateString to be a little more strict.

Fix 2: In the process, it turns out my intuition here was correct: https://github.com/JakeWharton/timber/pull/421#discussion_r684517508

In running `tagTooLongLiteralPlusFieldOnlyBeforeApi26` against ISSUE_BINARY, `context.project.minSdk` evaluates to `false` and actually fails with ISSUE_BINARY, upon which it also appends this error:

```
Lint results computed provisionally do
not match those computed without provisional support enabled. This
means that the detector is not handling provisional support correctly,
which means that it will not work correctly as part of incremental
Gradle builds, where projects are now analyzed separately and the
results merged to generate the report.

Alternatively, if this difference is expected, you can set the
`testModes(...)` to include only one of these two, or turn off
the equality check altogether via `.expectIdenticalTestModeOutput(false)`.
You can then check each output by passing in a `testMode` parameter
to `expect`(...). expected:<[UInjectionHost Enabled:

src/foo/Example.java:6: Warning: Replace String concatenation with Timber's string formatting [BinaryOperationInTimber]
     Timber.tag("abcdefghijklmnopqrstuvw" + field);
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
0 errors, 1 warnings
]> but was:<[Automatic Partial Analysis and Merging:

No warnings.]>
```

By removing the context.project early check, we have no way of knowing if the Lint actually reports based on the minSdk constraint.  Consequently, we also eliminate the early return for ISSUE_TAG_LENGTH issues and related tests which combined ISSUE_TAG_LENGTH and ISSUE_BINARY issues.

Closes #434.