### PR TITLE
Clickable Log source extension added

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Optional:
 
 To get clickable log source location in Logcat:
 
- - Append extension `timberSource` (returns String) with log message.
- - Append extension `TimberKt.getTimberSource()` (returns String) with log message.
+ - Kotlin: Append extension `timberSource` (returns String) with log message.
+ - Java: Append extension `TimberKt.getTimberSource()` (returns String) with log message.
 
 
 Check out the sample app in `timber-sample/` to see it in action.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ Two easy steps:
  1. Install any `Tree` instances you want in the `onCreate` of your application class.
  2. Call `Timber`'s static methods everywhere throughout your app.
 
+Optional:
+--------
+
+To get clickable log source location in Logcat:
+
+ - Append extension `timberSource` (returns String) with log message.
+ - Append extension `TimberKt.getTimberSource()` (returns String) with log message.
+
+
 Check out the sample app in `timber-sample/` to see it in action.
 
 

--- a/timber-sample/build.gradle
+++ b/timber-sample/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 android {
   compileSdkVersion versions.compileSdk

--- a/timber-sample/src/main/java/com/example/timber/ui/DemoActivity.java
+++ b/timber-sample/src/main/java/com/example/timber/ui/DemoActivity.java
@@ -11,6 +11,7 @@ import android.widget.Toast;
 import com.example.timber.databinding.DemoActivityBinding;
 
 import timber.log.Timber;
+import timber.log.TimberKt;
 
 public class DemoActivity extends Activity implements View.OnClickListener {
   @Override protected void onCreate(Bundle savedInstanceState) {
@@ -19,7 +20,8 @@ public class DemoActivity extends Activity implements View.OnClickListener {
     setContentView(binding.getRoot());
 
     Timber.tag("LifeCycles");
-    Timber.d("Activity Created");
+    //TimberKt.getTimberSource() to print clickable log location
+    Timber.d(TimberKt.getTimberSource() + " Activity Created");
 
     binding.hello.setOnClickListener(this);
     binding.hey.setOnClickListener(this);
@@ -28,7 +30,7 @@ public class DemoActivity extends Activity implements View.OnClickListener {
 
   @Override public void onClick(View v) {
     Button button = (Button) v;
-    Timber.i("A button with ID %s was clicked to say '%s'.", button.getId(), button.getText());
+    Timber.i(TimberKt.getTimberSource() + "A button with ID %s was clicked to say '%s'.", button.getId(), button.getText());
     Toast.makeText(this, "Check logcat for a greeting!", LENGTH_SHORT).show();
   }
 }

--- a/timber-sample/src/main/java/com/example/timber/ui/DemoActivityKotlin.kt
+++ b/timber-sample/src/main/java/com/example/timber/ui/DemoActivityKotlin.kt
@@ -1,0 +1,27 @@
+package com.example.timber.ui
+
+import android.app.Activity
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import com.example.timber.databinding.DemoActivityBinding
+import timber.log.Timber
+import timber.log.timberSource
+
+class DemoActivityKotlin: Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val binding: DemoActivityBinding = DemoActivityBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        //$timberSource to print clickable log location
+        Timber.d("$timberSource Activity Created")
+
+        binding.hello.setOnClickListener {
+            Timber.d("$timberSource Click_Hello")
+        }
+
+    }
+
+}

--- a/timber/src/main/java/timber/log/Timber.kt
+++ b/timber/src/main/java/timber/log/Timber.kt
@@ -195,16 +195,16 @@ class Timber private constructor() {
   /** A [Tree] for debug builds. Automatically infers the tag from the calling class. */
   open class DebugTree : Tree() {
     private val fqcnIgnore = listOf(
-        Timber::class.java.name,
-        Timber.Forest::class.java.name,
-        Tree::class.java.name,
-        DebugTree::class.java.name
+      Timber::class.java.name,
+      Timber.Forest::class.java.name,
+      Tree::class.java.name,
+      DebugTree::class.java.name
     )
 
     override val tag: String?
       get() = super.tag ?: Throwable().stackTrace
-          .first { it.className !in fqcnIgnore }
-          .let(::createStackElementTag)
+        .first { it.className !in fqcnIgnore }
+        .let(::createStackElementTag)
 
     /**
      * Extract the tag which should be used for the message from the `element`. By default
@@ -212,7 +212,7 @@ class Timber private constructor() {
      * becomes `Foo`).
      *
      * Note: This will not be called if a [manual tag][.tag] was specified.
-    */
+     */
     protected open fun createStackElementTag(element: StackTraceElement): String? {
       var tag = element.className.substringAfterLast('.')
       val m = ANONYMOUS_CLASS.matcher(tag)
@@ -233,7 +233,7 @@ class Timber private constructor() {
      * [Log.wtf()][Log.wtf] for logging.
      *
      * {@inheritDoc}
-    */
+     */
     override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
       if (message.length < MAX_LOG_LENGTH) {
         if (priority == Log.ASSERT) {
@@ -385,10 +385,10 @@ class Timber private constructor() {
     /**
      * A view into Timber's planted trees as a tree itself. This can be used for injecting a logger
      * instance rather than using static methods or to facilitate testing.
-    */
+     */
     @Suppress(
-        "NOTHING_TO_INLINE", // Kotlin users should reference `Tree.Forest` directly.
-        "NON_FINAL_MEMBER_IN_OBJECT" // For japicmp check.
+      "NOTHING_TO_INLINE", // Kotlin users should reference `Tree.Forest` directly.
+      "NON_FINAL_MEMBER_IN_OBJECT" // For japicmp check.
     )
     @JvmStatic
     open inline fun asTree(): Tree = this
@@ -453,3 +453,12 @@ class Timber private constructor() {
     @Volatile private var treeArray = emptyArray<Tree>()
   }
 }
+
+/**
+ *  Returns Clickable Filename:LineNumber in logcat
+ */
+val timberSource: String
+  get() {
+    val stackTrace = Thread.currentThread().stackTrace[3]
+    return "(${stackTrace.fileName}:${stackTrace.lineNumber})"
+  }


### PR DESCRIPTION
Added an extension to print clickable log source location in Logcat.
Examples in timber-sample.