### PR TITLE
Making possible to add wrapped class name to ignore list

### DIFF
--- a/timber/src/main/java/timber/log/Timber.kt
+++ b/timber/src/main/java/timber/log/Timber.kt
@@ -200,10 +200,11 @@ class Timber private constructor() {
         Tree::class.java.name,
         DebugTree::class.java.name
     )
+    protected open val customIgnoredClassNameList = emptyList<String>()
 
     override val tag: String?
       get() = super.tag ?: Throwable().stackTrace
-          .first { it.className !in fqcnIgnore }
+          .first { it.className !in (fqcnIgnore+customIgnoredClassNameList) }
           .let(::createStackElementTag)
 
     /**

--- a/timber/src/test/java/timber/log/loggerfacade/LoggerFacade.kt
+++ b/timber/src/test/java/timber/log/loggerfacade/LoggerFacade.kt
@@ -1,0 +1,10 @@
+package timber.log.loggerfacade
+
+import timber.log.Timber
+
+//This is just example facade object that uses Timber for logging
+object LoggerFacade{
+    fun d(message: String){
+        Timber.d(message)
+    }
+}


### PR DESCRIPTION
When creating wrapper class which uses Timber logging internally, tag name will be wrapper class name by default. When creating DebugTree, customIgnoredClassNameList can be overrided which makes it possible to add wrapper class name to customIgnoredClassNameList, so tag name will be more clear, making it possible to see where logging is actually called.

```
val debugTree=object :Timber.DebugTree(){
      override val customIgnoredClassNameList: List<String>
        get() = listOf(LoggerFacade::class.java.name)
    }
```