### PR TITLE
[Gradle 8] Update japicmp to use strictly instead of force

### DIFF
--- a/timber/japicmp/build.gradle
+++ b/timber/japicmp/build.gradle
@@ -4,9 +4,11 @@ configurations {
 }
 
 dependencies {
-  baseline('com.jakewharton.timber:timber:4.7.1') {
+  baseline('com.jakewharton.timber:timber') {
+    version {
+      strictly "4.7.1"
+    }
     transitive = false
-    force = true
   }
   latest project(path: ':timber', configuration: 'releaseRuntimeElements')
 }


### PR DESCRIPTION
Updates the japicmp dependency baseline to use `strictly` syntax instead of `force` syntax. I believe this is a syntax-only change.

This is necessary to migrate to gradle version >= 8, as 'force' is deprecated starting with 8 and it's use will cause the build to fail.

While it is not strictly necessary to update the gradle version, I am hoping to add KMP support in the near future, and having a more modern gradle wrapper will make that support easier.

Additional changes are necessary to support gradle version >= 8. I'm aiming to keep each PR as small as possible to facilitate ease of review.