### PR TITLE
compileSdk 36

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ androidTools = "31.12.1" # Update this values in sync with agp.
 kotlin = "2.2.10"
 autoService = "1.1.1"
 minSdk = "14"
-compileSdk = "30"
+compileSdk = "36"
 
 [libraries]
 gradlePlugin-android = { module = "com.android.tools.build:gradle", version.ref = "agp" }


### PR DESCRIPTION
AGP 9's view binding requires at least compileSdk 34. Found via https://github.com/JakeWharton/prerelease-testing/actions/runs/17141662112/job/48630173648?pr=110