### PR TITLE
Fix: TimberExceptionLogging gives false positive for guarded variables

### DIFF
--- a/timber-lint/lint-baseline.xml
+++ b/timber-lint/lint-baseline.xml
@@ -1,16 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.10.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.10.0)" variant="all" version="8.10.0">
-
-    <issue
-        id="JavaPluginLanguageLevel"
-        message="no Java language level directives"
-        errorLine1="apply plugin: &apos;java-library&apos;"
-        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="build.gradle"
-            line="1"
-            column="1"/>
-    </issue>
+<issues format="6" by="lint 8.12.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.12.0)" variant="all" version="8.12.0">
 
     <issue
         id="LintImplTextFormat"
@@ -19,7 +8,7 @@
         errorLine2="                                                                                              ~~~~~~~~">
         <location
             file="src/main/java/timber/lint/WrongTimberUsageDetector.kt"
-            line="741"
+            line="760"
             column="95"/>
     </issue>
 
@@ -30,7 +19,7 @@
         errorLine2="                                                 ~~~~~~~~">
         <location
             file="src/main/java/timber/lint/WrongTimberUsageDetector.kt"
-            line="759"
+            line="778"
             column="50"/>
     </issue>
 
@@ -41,7 +30,7 @@
         errorLine2="                                ~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="552"
+            line="684"
             column="33"/>
     </issue>
 
@@ -52,256 +41,190 @@
         errorLine2="                                   ~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="589"
+            line="733"
             column="36"/>
     </issue>
 
     <issue
         id="LintImplDollarEscapes"
         message="In unit tests, use the fullwidth dollar sign, `＄`, instead of `$`, to avoid having to use cumbersome escapes. Lint will treat a `＄` as a `$`."
-        errorLine1="                |     Timber.d(&quot;${&quot;$&quot;}foo${&quot;$&quot;}bar&quot;)"
+        errorLine1="                |     Timber.d(&quot;${&quot;$&quot;}{foo}${&quot;$&quot;}bar&quot;)"
         errorLine2="                                ~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="628"
+            line="784"
             column="33"/>
     </issue>
 
     <issue
         id="LintImplDollarEscapes"
         message="In unit tests, use the fullwidth dollar sign, `＄`, instead of `$`, to avoid having to use cumbersome escapes. Lint will treat a `＄` as a `$`."
-        errorLine1="                |     Timber.d(if(true) &quot;Hello, ${&quot;$&quot;}s&quot; else &quot;Bye&quot;)"
+        errorLine1="                |     Timber.d(if(true) &quot;Hello, ${&quot;$&quot;}{s}&quot; else &quot;Bye&quot;)"
         errorLine2="                                                ~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="665"
+            line="833"
             column="49"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="35"
+            line="40"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="43"
+            line="50"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="85"
+            line="100"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="93"
+            line="110"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="134"
+            line="159"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="141"
+            line="168"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="182"
+            line="217"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="189"
+            line="226"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="231"
+            line="277"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="239"
+            line="287"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="274"
+            line="332"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="283"
+            line="343"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="321"
+            line="388"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="330"
+            line="399"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
-        errorLine2="                      ~~~~~~~~~~~~">
-        <location
-            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="355"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
-        errorLine2="                      ~~~~~~~~~~~~">
-        <location
-            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="378"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
-        errorLine2="                      ~~~~~~~~~~~~">
-        <location
-            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="387"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
-        errorLine2="                      ~~~~~~~~~~~~">
-        <location
-            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="403"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
-        errorLine2="                      ~~~~~~~~~~~~">
-        <location
-            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="410"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
-        errorLine2="                      ~~~~~~~~~~~~">
-        <location
-            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="424"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
@@ -312,348 +235,271 @@
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="              |}&quot;&quot;&quot;.trimMargin()),"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
+            line="461"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="LintImplTrimIndent"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
+            line="472"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="LintImplTrimIndent"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
+            line="493"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="LintImplTrimIndent"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
+            line="502"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="LintImplTrimIndent"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
+            line="521"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="LintImplTrimIndent"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
+            line="530"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="LintImplTrimIndent"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
+        errorLine1="              |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                    ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="449"
+            line="553"
             column="21"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="              |}&quot;&quot;&quot;.trimMargin()),"
+        errorLine1="              |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                    ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="458"
+            line="564"
             column="21"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="476"
+            line="587"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="485"
+            line="598"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="519"
+            line="642"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="527"
+            line="652"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="545"
+            line="675"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="554"
+            line="686"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="582"
+            line="724"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="591"
+            line="735"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="620"
+            line="774"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="630"
+            line="786"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="658"
+            line="824"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="667"
+            line="835"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="688"
+            line="864"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="696"
+            line="874"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="720"
+            line="905"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="728"
+            line="915"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
-        errorLine2="                      ~~~~~~~~~~~~">
-        <location
-            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="752"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
-        errorLine2="                      ~~~~~~~~~~~~">
-        <location
-            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="760"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
-        errorLine2="                      ~~~~~~~~~~~~">
-        <location
-            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="784"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
-        errorLine2="                      ~~~~~~~~~~~~">
-        <location
-            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="792"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
-        errorLine2="                      ~~~~~~~~~~~~">
-        <location
-            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="814"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
-        errorLine2="                      ~~~~~~~~~~~~">
-        <location
-            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="822"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
-        errorLine2="                      ~~~~~~~~~~~~">
-        <location
-            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="840"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
-        errorLine2="                      ~~~~~~~~~~~~">
-        <location
-            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="848"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
-        errorLine2="                      ~~~~~~~~~~~~">
-        <location
-            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="872"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
-        errorLine2="                      ~~~~~~~~~~~~">
-        <location
-            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="880"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
-        errorLine2="                      ~~~~~~~~~~~~">
-        <location
-            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="904"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
-        errorLine2="                      ~~~~~~~~~~~~">
-        <location
-            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="912"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
-        errorLine2="                      ~~~~~~~~~~~~">
-        <location
-            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="937"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
@@ -663,30 +509,41 @@
 
     <issue
         id="LintImplTrimIndent"
-        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="981"
+            line="956"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="LintImplTrimIndent"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
+            line="987"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="990"
+            line="997"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
@@ -697,7 +554,7 @@
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
@@ -708,183 +565,128 @@
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="1053"
+            line="1059"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="1061"
+            line="1069"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="1081"
+            line="1100"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="1092"
+            line="1110"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="1111"
+            line="1141"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="1121"
+            line="1151"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="1140"
+            line="1183"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="1150"
+            line="1194"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="1168"
+            line="1238"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="1177"
+            line="1249"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="1212"
+            line="1295"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
-        errorLine2="                      ~~~~~~~~~~~~">
-        <location
-            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="1221"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
-        errorLine2="                      ~~~~~~~~~~~~">
-        <location
-            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="1256"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
-        errorLine2="                      ~~~~~~~~~~~~">
-        <location
-            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="1265"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
-        errorLine2="                      ~~~~~~~~~~~~">
-        <location
-            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="1282"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
-        errorLine2="                      ~~~~~~~~~~~~">
-        <location
-            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="1290"
-            column="23"/>
-    </issue>
-
-    <issue
-        id="LintImplTrimIndent"
-        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
@@ -894,46 +696,244 @@
 
     <issue
         id="LintImplTrimIndent"
-        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin())"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="1315"
+            line="1330"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="LintImplTrimIndent"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
+            line="1340"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                |}&quot;&quot;&quot;.trimMargin()),"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
         errorLine2="                      ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="1332"
+            line="1366"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="LintImplTrimIndent"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
+            line="1379"
             column="23"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
-        errorLine1="                &quot;&quot;&quot;.trimMargin()),"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
+            line="1404"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="LintImplTrimIndent"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
+            line="1416"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="LintImplTrimIndent"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
+            line="1441"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="LintImplTrimIndent"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
+            line="1453"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="LintImplTrimIndent"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
+            line="1477"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="LintImplTrimIndent"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
+            line="1488"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="LintImplTrimIndent"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
+            line="1533"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="LintImplTrimIndent"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
+            line="1544"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="LintImplTrimIndent"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
+            line="1589"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="LintImplTrimIndent"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
+            line="1600"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="LintImplTrimIndent"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
+            line="1623"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="LintImplTrimIndent"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
+            line="1633"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="LintImplTrimIndent"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
+            line="1655"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="LintImplTrimIndent"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
+            line="1665"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="LintImplTrimIndent"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
+        errorLine1="                |}&quot;&quot;&quot;.trimMargin()"
+        errorLine2="                      ~~~~~~~~~~~~">
+        <location
+            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
+            line="1687"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="LintImplTrimIndent"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `java()` test file construction"
+        errorLine1="                &quot;&quot;&quot;.trimMargin()"
         errorLine2="                    ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="1355"
+            line="1715"
             column="21"/>
     </issue>
 
     <issue
         id="LintImplTrimIndent"
         message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
-        errorLine1="                &quot;&quot;&quot;.trimMargin())"
+        errorLine1="                &quot;&quot;&quot;.trimMargin()"
         errorLine2="                    ~~~~~~~~~~~~">
         <location
             file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
-            line="1368"
+            line="1730"
             column="21"/>
+    </issue>
+
+    <issue
+        id="LintImplTrimIndent"
+        message="No need to call `.trimMargin()` in issue registration strings; they are already trimmed by indent by lint when displaying to users. Instead, call `.indented()` on the surrounding `kotlin()` test file construction"
+        errorLine1="              &quot;&quot;&quot;.trimMargin()"
+        errorLine2="                  ~~~~~~~~~~~~">
+        <location
+            file="src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt"
+            line="1767"
+            column="19"/>
     </issue>
 
     <issue
@@ -943,7 +943,7 @@
         errorLine2="        ~~~~~~~~~~">
         <location
             file="src/main/java/timber/lint/WrongTimberUsageDetector.kt"
-            line="279"
+            line="283"
             column="9"/>
     </issue>
 
@@ -954,7 +954,7 @@
         errorLine2="               ~~~~~~~~~~">
         <location
             file="src/main/java/timber/lint/WrongTimberUsageDetector.kt"
-            line="286"
+            line="290"
             column="16"/>
     </issue>
 

--- a/timber-lint/src/main/java/timber/lint/WrongTimberUsageDetector.kt
+++ b/timber-lint/src/main/java/timber/lint/WrongTimberUsageDetector.kt
@@ -1,32 +1,7 @@
 package timber.lint
 
-import com.android.tools.lint.detector.api.skipParentheses
-import org.jetbrains.uast.util.isMethodCall
-import com.android.tools.lint.detector.api.minSdkLessThan
-import com.android.tools.lint.detector.api.isString
-import com.android.tools.lint.detector.api.isKotlin
-import org.jetbrains.uast.isInjectionHost
-import org.jetbrains.uast.evaluateString
-import com.android.tools.lint.detector.api.Detector
-import com.android.tools.lint.detector.api.JavaContext
-import org.jetbrains.uast.UCallExpression
-import com.intellij.psi.PsiMethod
-import com.android.tools.lint.client.api.JavaEvaluator
-import com.android.tools.lint.detector.api.LintFix
-import org.jetbrains.uast.UElement
-import com.intellij.psi.PsiTypes
-import org.jetbrains.uast.UMethod
-import org.jetbrains.uast.UExpression
-import com.android.tools.lint.detector.api.Incident
-import org.jetbrains.uast.UQualifiedReferenceExpression
-import org.jetbrains.uast.UBinaryExpression
-import org.jetbrains.uast.UastBinaryOperator
-import org.jetbrains.uast.UIfExpression
-import com.intellij.psi.PsiMethodCallExpression
-import com.intellij.psi.PsiLiteralExpression
-import com.intellij.psi.PsiType
-import com.intellij.psi.PsiClassType
 import com.android.tools.lint.checks.StringFormatDetector
+import com.android.tools.lint.client.api.JavaEvaluator
 import com.android.tools.lint.client.api.TYPE_BOOLEAN
 import com.android.tools.lint.client.api.TYPE_BOOLEAN_WRAPPER
 import com.android.tools.lint.client.api.TYPE_BYTE
@@ -48,16 +23,38 @@ import com.android.tools.lint.client.api.TYPE_STRING
 import com.android.tools.lint.detector.api.Category.Companion.CORRECTNESS
 import com.android.tools.lint.detector.api.Category.Companion.MESSAGES
 import com.android.tools.lint.detector.api.ConstantEvaluator.evaluateString
+import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.Detector.UastScanner
 import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Incident
 import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.LintFix
 import com.android.tools.lint.detector.api.Scope.Companion.JAVA_FILE_SCOPE
 import com.android.tools.lint.detector.api.Severity.ERROR
 import com.android.tools.lint.detector.api.Severity.WARNING
+import com.android.tools.lint.detector.api.isKotlin
+import com.android.tools.lint.detector.api.isString
+import com.android.tools.lint.detector.api.minSdkLessThan
+import com.android.tools.lint.detector.api.skipParentheses
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiLiteralExpression
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.psi.PsiType
+import com.intellij.psi.PsiTypes
+import org.jetbrains.uast.UBinaryExpression
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UExpression
+import org.jetbrains.uast.UIfExpression
 import org.jetbrains.uast.ULiteralExpression
-import org.jetbrains.uast.USimpleNameReferenceExpression
-import com.intellij.psi.PsiField
-import com.intellij.psi.PsiParameter
+import org.jetbrains.uast.UMethod
+import org.jetbrains.uast.UQualifiedReferenceExpression
+import org.jetbrains.uast.UastBinaryOperator
+import org.jetbrains.uast.evaluateString
+import org.jetbrains.uast.isInjectionHost
+import org.jetbrains.uast.util.isMethodCall
 import java.lang.Byte
 import java.lang.Double
 import java.lang.Float
@@ -67,6 +64,12 @@ import java.lang.Short
 import java.util.Calendar
 import java.util.Date
 import java.util.regex.Pattern
+import kotlin.Any
+import kotlin.Boolean
+import kotlin.Number
+import kotlin.String
+import kotlin.Throwable
+import kotlin.arrayOf
 
 class WrongTimberUsageDetector : Detector(), UastScanner {
   override fun getApplicableMethodNames() = listOf("tag", "format", "v", "d", "i", "w", "e", "wtf")
@@ -77,7 +80,7 @@ class WrongTimberUsageDetector : Detector(), UastScanner {
 
     if ("format" == methodName &&
       (evaluator.isMemberInClass(method, "java.lang.String") ||
-          evaluator.isMemberInClass(method, "kotlin.text.StringsKt__StringsJVMKt"))
+        evaluator.isMemberInClass(method, "kotlin.text.StringsKt__StringsJVMKt"))
     ) {
       checkNestedStringFormat(context, node)
       return
@@ -106,9 +109,9 @@ class WrongTimberUsageDetector : Detector(), UastScanner {
   }
 
   private fun isTimberLogMethod(method: PsiMethod, evaluator: JavaEvaluator): Boolean {
-    return evaluator.isMemberInClass(method, "timber.log.Timber")
-        || evaluator.isMemberInClass(method, "timber.log.Timber.Companion")
-        || evaluator.isMemberInClass(method, "timber.log.Timber.Tree")
+    return evaluator.isMemberInClass(method, "timber.log.Timber") ||
+      evaluator.isMemberInClass(method, "timber.log.Timber.Companion") ||
+      evaluator.isMemberInClass(method, "timber.log.Timber.Tree")
   }
 
   private fun checkNestedStringFormat(context: JavaContext, call: UCallExpression) {
@@ -122,8 +125,8 @@ class WrongTimberUsageDetector : Detector(), UastScanner {
       if (current.isMethodCall()) {
         val psiMethod = (current as UCallExpression).resolve()
         if (psiMethod != null &&
-          Pattern.matches(TIMBER_TREE_LOG_METHOD_REGEXP, psiMethod.name)
-          && isTimberLogMethod(psiMethod, context.evaluator)
+          Pattern.matches(TIMBER_TREE_LOG_METHOD_REGEXP, psiMethod.name) &&
+          isTimberLogMethod(psiMethod, context.evaluator)
         ) {
           context.report(
             Incident(
@@ -224,7 +227,7 @@ class WrongTimberUsageDetector : Detector(), UastScanner {
           'B', 'b', 'h', 'A', 'a', 'C', 'Y', 'y', 'j', 'm', 'd', 'e', // date
           'R', 'T', 'r', 'D', 'F', 'c' -> { // date/time
             valid =
-              type == Integer.TYPE || type == Calendar::class.java || type == Date::class.java || type == java.lang.Long.TYPE
+              type == Integer.TYPE || type == Calendar::class.java || type == Date::class.java || type == Long.TYPE
             if (!valid) {
               context.report(
                 Incident(
@@ -253,7 +256,7 @@ class WrongTimberUsageDetector : Detector(), UastScanner {
       valid = when (last) {
         'b', 'B' -> type == java.lang.Boolean.TYPE
         'x', 'X', 'd', 'o', 'e', 'E', 'f', 'g', 'G', 'a', 'A' -> {
-          type == Integer.TYPE || type == java.lang.Float.TYPE || type == java.lang.Double.TYPE || type == java.lang.Long.TYPE || type == java.lang.Byte.TYPE || type == java.lang.Short.TYPE
+          type == Integer.TYPE || type == Float.TYPE || type == Double.TYPE || type == Long.TYPE || type == Byte.TYPE || type == Short.TYPE
         }
         'c', 'C' -> type == Character.TYPE
         'h', 'H' -> type != java.lang.Boolean.TYPE && !Number::class.java.isAssignableFrom(type)
@@ -290,7 +293,7 @@ class WrongTimberUsageDetector : Detector(), UastScanner {
       when {
         isString(expressionType!!) -> return String::class.java
         expressionType === PsiTypes.intType() -> return Integer.TYPE
-        expressionType === PsiTypes.floatType() -> return java.lang.Float.TYPE
+        expressionType === PsiTypes.floatType() -> return Float.TYPE
         expressionType === PsiTypes.charType() -> return Character.TYPE
         expressionType === PsiTypes.booleanType() -> return java.lang.Boolean.TYPE
         expressionType === PsiTypes.nullType() -> return Any::class.java
@@ -450,11 +453,12 @@ class WrongTimberUsageDetector : Detector(), UastScanner {
     val numArguments = arguments.size
 
     // Find the throwable and message arguments by their type, not by their position.
-    // This is required to correctly handle Kotlin's named and reordered arguments.
     val throwableArgument = arguments.firstOrNull { isSubclassOf(context, it, Throwable::class.java) }
+
+    // Find an argument that is either a String OR a literal null expression.
     val messageArgument = arguments.firstOrNull {
       val type = it.getExpressionType()
-      type != null && isString(type) && it != throwableArgument
+      (type != null && isString(type)) || (it is ULiteralExpression && it.isNull)
     }
 
     // Handles overloads like Timber.d(t, "message").
@@ -473,7 +477,21 @@ class WrongTimberUsageDetector : Detector(), UastScanner {
         return
       }
 
-      // Attempt to evaluate the message argument to a constant string at compile time.
+      // Check if the argument is a literal null, which is a clear issue.
+      if (messageArgument is ULiteralExpression && messageArgument.isNull) {
+        context.report(
+          Incident(
+            issue = ISSUE_EXCEPTION_LOGGING,
+            scope = messageArgument,
+            location = context.getLocation(call),
+            message = "Use single-argument log method instead of null/empty message",
+            fix = quickFixRemoveRedundantArgument(messageArgument)
+          )
+        )
+        return
+      }
+
+      // If it's not null, then try to evaluate it as a string.
       val messageValue = evaluateString(context, messageArgument, true)
 
       // If we could determine the string's value (i.e., it's a literal or constant)...
@@ -492,8 +510,7 @@ class WrongTimberUsageDetector : Detector(), UastScanner {
         }
       }
       // If messageValue is null, the argument is a variable or method call. We intentionally
-      // do nothing in this case to avoid false positives, as we cannot determine its runtime
-      // value (e.g., it might be guarded by an `if` check). This fixes the reported issue.
+      // do nothing in this case to avoid false positives.
 
       // Handles single-argument overloads like Timber.d("message").
     } else if (numArguments == 1 && throwableArgument == null && messageArgument != null) {
@@ -534,16 +551,13 @@ class WrongTimberUsageDetector : Detector(), UastScanner {
     )
   }
 
-  // This function is no longer needed after changes and has been removed.
-  // private fun canEvaluateExpression(...) { ... }
-
   private fun isCallFromMethodInSubclassOf(
     context: JavaContext, call: UCallExpression, methodName: String, classType: Class<*>
   ): Boolean {
     val method = call.resolve()
-    return method != null
-        && methodName == call.methodName
-        && context.evaluator.isMemberInSubClassOf(method, classType.canonicalName, false)
+    return method != null &&
+      methodName == call.methodName &&
+      context.evaluator.isMemberInSubClassOf(method, classType.canonicalName, false)
   }
 
   private fun isPropertyOnSubclassOf(
@@ -552,8 +566,8 @@ class WrongTimberUsageDetector : Detector(), UastScanner {
     propertyName: String,
     classType: Class<*>
   ): Boolean {
-    return isSubclassOf(context, expression.receiver, classType)
-        && expression.selector.asSourceString() == propertyName
+    return isSubclassOf(context, expression.receiver, classType) &&
+      expression.selector.asSourceString() == propertyName
   }
 
   private fun checkElement(
@@ -564,8 +578,8 @@ class WrongTimberUsageDetector : Detector(), UastScanner {
       if (operator === UastBinaryOperator.PLUS || operator === UastBinaryOperator.PLUS_ASSIGN) {
         val argumentType = getType(element)
         if (argumentType == String::class.java) {
-          if (element.leftOperand.isInjectionHost()
-            && element.rightOperand.isInjectionHost()
+          if (element.leftOperand.isInjectionHost() &&
+            element.rightOperand.isInjectionHost()
           ) {
             return false
           }

--- a/timber-lint/src/main/java/timber/lint/WrongTimberUsageDetector.kt
+++ b/timber-lint/src/main/java/timber/lint/WrongTimberUsageDetector.kt
@@ -448,50 +448,63 @@ class WrongTimberUsageDetector : Detector(), UastScanner {
   private fun checkExceptionLogging(context: JavaContext, call: UCallExpression) {
     val arguments = call.valueArguments
     val numArguments = arguments.size
-    if (numArguments > 1 && isSubclassOf(context, arguments[0], Throwable::class.java)) {
-      val messageArg = arguments[1]
 
-      if (isLoggingExceptionMessage(context, messageArg)) {
+    // Find the throwable and message arguments by their type, not by their position.
+    // This is required to correctly handle Kotlin's named and reordered arguments.
+    val throwableArgument = arguments.firstOrNull { isSubclassOf(context, it, Throwable::class.java) }
+    val messageArgument = arguments.firstOrNull {
+      val type = it.getExpressionType()
+      type != null && isString(type) && it != throwableArgument
+    }
+
+    // Handles overloads like Timber.d(t, "message").
+    if (throwableArgument != null && messageArgument != null) {
+      // Check for the common mistake of explicitly logging the exception's own message.
+      if (isLoggingExceptionMessage(context, messageArgument)) {
         context.report(
           Incident(
             issue = ISSUE_EXCEPTION_LOGGING,
-            scope = messageArg,
+            scope = messageArgument,
             location = context.getLocation(call),
             message = "Explicitly logging exception message is redundant",
-            fix = quickFixRemoveRedundantArgument(messageArg)
+            fix = quickFixRemoveRedundantArgument(messageArgument)
           )
         )
         return
       }
 
-      val s = evaluateString(context, messageArg, true)
-      if (s == null && !canEvaluateExpression(messageArg)) {
-        // Parameters and non-final fields can't be evaluated.
-        return
-      }
+      // Attempt to evaluate the message argument to a constant string at compile time.
+      val messageValue = evaluateString(context, messageArgument, true)
 
-      if (s == null || s.isEmpty()) {
-        context.report(
-          Incident(
-            issue = ISSUE_EXCEPTION_LOGGING,
-            scope = messageArg,
-            location = context.getLocation(call),
-            message = "Use single-argument log method instead of null/empty message",
-            fix = quickFixRemoveRedundantArgument(messageArg)
+      // If we could determine the string's value (i.e., it's a literal or constant)...
+      if (messageValue != null) {
+        // ...then we can safely check if it's empty and report an issue.
+        if (messageValue.isEmpty()) {
+          context.report(
+            Incident(
+              issue = ISSUE_EXCEPTION_LOGGING,
+              scope = messageArgument,
+              location = context.getLocation(call),
+              message = "Use single-argument log method instead of null/empty message",
+              fix = quickFixRemoveRedundantArgument(messageArgument)
+            )
           )
-        )
+        }
       }
-    } else if (numArguments == 1 && !isSubclassOf(context, arguments[0], Throwable::class.java)) {
-      val messageArg = arguments[0]
+      // If messageValue is null, the argument is a variable or method call. We intentionally
+      // do nothing in this case to avoid false positives, as we cannot determine its runtime
+      // value (e.g., it might be guarded by an `if` check). This fixes the reported issue.
 
-      if (isLoggingExceptionMessage(context, messageArg)) {
+      // Handles single-argument overloads like Timber.d("message").
+    } else if (numArguments == 1 && throwableArgument == null && messageArgument != null) {
+      if (isLoggingExceptionMessage(context, messageArgument)) {
         context.report(
           Incident(
             issue = ISSUE_EXCEPTION_LOGGING,
-            scope = messageArg,
+            scope = messageArgument,
             location = context.getLocation(call),
             message = "Explicitly logging exception message is redundant",
-            fix = quickFixReplaceMessageWithThrowable(messageArg)
+            fix = quickFixReplaceMessageWithThrowable(messageArgument)
           )
         )
       }
@@ -521,17 +534,8 @@ class WrongTimberUsageDetector : Detector(), UastScanner {
     )
   }
 
-  private fun canEvaluateExpression(expression: UExpression): Boolean {
-    // TODO - try using CallGraph?
-    if (expression is ULiteralExpression) {
-      return true
-    }
-    if (expression !is USimpleNameReferenceExpression) {
-      return false
-    }
-    val resolvedElement = expression.resolve()
-    return !(resolvedElement is PsiField || resolvedElement is PsiParameter)
-  }
+  // This function is no longer needed after changes and has been removed.
+  // private fun canEvaluateExpression(...) { ... }
 
   private fun isCallFromMethodInSubclassOf(
     context: JavaContext, call: UCallExpression, methodName: String, classType: Class<*>

--- a/timber-lint/src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt
+++ b/timber-lint/src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt
@@ -9,8 +9,8 @@ import org.junit.Test
 import timber.lint.WrongTimberUsageDetector.Companion.issues
 
 class WrongTimberUsageDetectorTest {
-  private val TIMBER_STUB = kotlin(
-    """
+    private val TIMBER_STUB = kotlin(
+        """
       |package timber.log
       |class Timber private constructor() {
       |  private companion object {
@@ -23,14 +23,14 @@ class WrongTimberUsageDetectorTest {
       |    open fun d(t: Throwable?, message: String?, vararg args: Any?) {}
       |  }
       |}""".trimMargin()
-  )
+    )
 
-  @Test
-  fun usingAndroidLogWithTwoArguments() {
-    lint()
-      .files(
-        java(
-          """
+    @Test
+    fun usingAndroidLogWithTwoArguments() {
+        lint()
+            .files(
+                java(
+                    """
                 |package foo;
                 |import android.util.Log;
                 |public class Example {
@@ -38,9 +38,9 @@ class WrongTimberUsageDetectorTest {
                 |    Log.d("TAG", "msg");
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import android.util.Log
                 |class Example {
@@ -48,13 +48,13 @@ class WrongTimberUsageDetectorTest {
                 |    Log.d("TAG", "msg")
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .run()
-      .expect(
-        """
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .run()
+            .expect(
+                """
             |src/foo/Example.java:5: Warning: Using 'Log' instead of 'Timber' [LogNotTimber]
             |    Log.d("TAG", "msg");
             |    ~~~~~~~~~~~~~~~~~~~
@@ -62,9 +62,9 @@ class WrongTimberUsageDetectorTest {
             |    Log.d("TAG", "msg")
             |    ~~~~~~~~~~~~~~~~~~~
             |0 errors, 2 warnings""".trimMargin()
-      )
-      .expectFixDiffs(
-        """
+            )
+            .expectFixDiffs(
+                """
             |Fix for src/foo/Example.java line 5: Replace with Timber.tag("TAG").d("msg"):
             |@@ -5 +5
             |-     Log.d("TAG", "msg");
@@ -82,15 +82,15 @@ class WrongTimberUsageDetectorTest {
             |-     Log.d("TAG", "msg")
             |+     Timber.d("msg")
             |""".trimMargin()
-      )
-  }
+            )
+    }
 
-  @Test
-  fun usingAndroidLogWithThreeArguments() {
-    lint()
-      .files(
-        java(
-          """
+    @Test
+    fun usingAndroidLogWithThreeArguments() {
+        lint()
+            .files(
+                java(
+                    """
                 |package foo;
                 |import android.util.Log;
                 |public class Example {
@@ -98,9 +98,9 @@ class WrongTimberUsageDetectorTest {
                 |    Log.d("TAG", "msg", new Exception());
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import android.util.Log
                 |class Example {
@@ -108,13 +108,13 @@ class WrongTimberUsageDetectorTest {
                 |    Log.d("TAG", "msg", Exception())
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .run()
-      .expect(
-        """
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .run()
+            .expect(
+                """
             |src/foo/Example.java:5: Warning: Using 'Log' instead of 'Timber' [LogNotTimber]
             |    Log.d("TAG", "msg", new Exception());
             |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -122,9 +122,9 @@ class WrongTimberUsageDetectorTest {
             |    Log.d("TAG", "msg", Exception())
             |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             |0 errors, 2 warnings""".trimMargin()
-      )
-      .expectFixDiffs(
-        """
+            )
+            .expectFixDiffs(
+                """
             |Fix for src/foo/Example.java line 5: Replace with Timber.tag("TAG").d(new Exception(), "msg"):
             |@@ -5 +5
             |-     Log.d("TAG", "msg", new Exception());
@@ -142,37 +142,37 @@ class WrongTimberUsageDetectorTest {
             |-     Log.d("TAG", "msg", Exception())
             |+     Timber.d(Exception(), "msg")
             |""".trimMargin()
-      )
-  }
+            )
+    }
 
-  @Test
-  fun usingFullyQualifiedAndroidLogWithTwoArguments() {
-    lint()
-      .files(
-        java(
-          """
+    @Test
+    fun usingFullyQualifiedAndroidLogWithTwoArguments() {
+        lint()
+            .files(
+                java(
+                    """
                 |package foo;
                 |public class Example {
                 |  public void log() {
                 |    android.util.Log.d("TAG", "msg");
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |class Example {
                 |  fun log() {
                 |    android.util.Log.d("TAG", "msg")
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .run()
-      .expect(
-        """
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .run()
+            .expect(
+                """
             |src/foo/Example.java:4: Warning: Using 'Log' instead of 'Timber' [LogNotTimber]
             |    android.util.Log.d("TAG", "msg");
             |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -180,9 +180,9 @@ class WrongTimberUsageDetectorTest {
             |    android.util.Log.d("TAG", "msg")
             |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             |0 errors, 2 warnings""".trimMargin()
-      )
-      .expectFixDiffs(
-        """
+            )
+            .expectFixDiffs(
+                """
             |Fix for src/foo/Example.java line 4: Replace with Timber.tag("TAG").d("msg"):
             |@@ -4 +4
             |-     android.util.Log.d("TAG", "msg");
@@ -200,37 +200,37 @@ class WrongTimberUsageDetectorTest {
             |-     android.util.Log.d("TAG", "msg")
             |+     Timber.d("msg")
             |""".trimMargin()
-      )
-  }
+            )
+    }
 
-  @Test
-  fun usingFullyQualifiedAndroidLogWithThreeArguments() {
-    lint()
-      .files(
-        java(
-          """
+    @Test
+    fun usingFullyQualifiedAndroidLogWithThreeArguments() {
+        lint()
+            .files(
+                java(
+                    """
                 |package foo;
                 |public class Example {
                 |  public void log() {
                 |    android.util.Log.d("TAG", "msg", new Exception());
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |class Example {
                 |  fun log() {
                 |    android.util.Log.d("TAG", "msg", Exception())
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .run()
-      .expect(
-        """
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .run()
+            .expect(
+                """
             |src/foo/Example.java:4: Warning: Using 'Log' instead of 'Timber' [LogNotTimber]
             |    android.util.Log.d("TAG", "msg", new Exception());
             |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -238,9 +238,9 @@ class WrongTimberUsageDetectorTest {
             |    android.util.Log.d("TAG", "msg", Exception())
             |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             |0 errors, 2 warnings""".trimMargin()
-      )
-      .expectFixDiffs(
-        """
+            )
+            .expectFixDiffs(
+                """
             |Fix for src/foo/Example.java line 4: Replace with Timber.tag("TAG").d(new Exception(), "msg"):
             |@@ -4 +4
             |-     android.util.Log.d("TAG", "msg", new Exception());
@@ -258,16 +258,16 @@ class WrongTimberUsageDetectorTest {
             |-     android.util.Log.d("TAG", "msg", Exception())
             |+     Timber.d(Exception(), "msg")
             |""".trimMargin()
-      )
-  }
+            )
+    }
 
-  @Test
-  fun innerStringFormat() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun innerStringFormat() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -275,9 +275,9 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(String.format("%s", "arg1"));
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -285,14 +285,14 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(String.format("%s", "arg1"))
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .skipTestModes(TestMode.WHITESPACE)
-      .run()
-      .expect(
-        """
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .skipTestModes(TestMode.WHITESPACE)
+            .run()
+            .expect(
+                """
             |src/foo/Example.java:5: Warning: Using 'String#format' inside of 'Timber' [StringFormatInTimber]
             |     Timber.d(String.format("%s", "arg1"));
             |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -300,9 +300,9 @@ class WrongTimberUsageDetectorTest {
             |     Timber.d(String.format("%s", "arg1"))
             |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~
             |0 errors, 2 warnings""".trimMargin()
-      )
-      .expectFixDiffs(
-        """
+            )
+            .expectFixDiffs(
+                """
             |Fix for src/foo/Example.java line 5: Remove String.format(...):
             |@@ -5 +5
             |-      Timber.d(String.format("%s", "arg1"));
@@ -312,16 +312,16 @@ class WrongTimberUsageDetectorTest {
             |-      Timber.d(String.format("%s", "arg1"))
             |+      Timber.d("%s", "arg1")
             |""".trimMargin()
-      )
-  }
+            )
+    }
 
-  @Test
-  fun innerStringFormatWithStaticImport() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun innerStringFormatWithStaticImport() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |import static java.lang.String.format;
@@ -330,9 +330,9 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(format("%s", "arg1"));
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |import java.lang.String.format
@@ -341,14 +341,14 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(format("%s", "arg1"))
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .skipTestModes(TestMode.PARENTHESIZED, TestMode.WHITESPACE)
-      .run()
-      .expect(
-        """
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .skipTestModes(TestMode.PARENTHESIZED, TestMode.WHITESPACE)
+            .run()
+            .expect(
+                """
             |src/foo/Example.java:6: Warning: Using 'String#format' inside of 'Timber' [StringFormatInTimber]
             |     Timber.d(format("%s", "arg1"));
             |              ~~~~~~~~~~~~~~~~~~~~
@@ -356,9 +356,9 @@ class WrongTimberUsageDetectorTest {
             |     Timber.d(format("%s", "arg1"))
             |              ~~~~~~~~~~~~~~~~~~~~
             |0 errors, 2 warnings""".trimMargin()
-      )
-      .expectFixDiffs(
-        """
+            )
+            .expectFixDiffs(
+                """
             |Fix for src/foo/Example.java line 6: Remove String.format(...):
             |@@ -6 +6
             |-      Timber.d(format("%s", "arg1"));
@@ -368,16 +368,16 @@ class WrongTimberUsageDetectorTest {
             |-      Timber.d(format("%s", "arg1"))
             |+      Timber.d("%s", "arg1")
             |""".trimMargin()
-      )
-  }
+            )
+    }
 
-  @Test
-  fun innerStringFormatInNestedMethods() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun innerStringFormatInNestedMethods() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -386,9 +386,9 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |  private String id(String s) { return s; }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -397,13 +397,13 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |  private fun id(s: String): String { return s }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .run()
-      .expect(
-        """
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .run()
+            .expect(
+                """
             |src/foo/Example.java:5: Warning: Using 'String#format' inside of 'Timber' [StringFormatInTimber]
             |     Timber.d(id(String.format("%s", "arg1")));
             |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -411,16 +411,16 @@ class WrongTimberUsageDetectorTest {
             |     Timber.d(id(String.format("%s", "arg1")))
             |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
             |0 errors, 2 warnings""".trimMargin()
-      )
-  }
+            )
+    }
 
-  @Test
-  fun innerStringFormatInNestedAssignment() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun innerStringFormatInNestedAssignment() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -429,28 +429,28 @@ class WrongTimberUsageDetectorTest {
                 |    Timber.d(msg = String.format("msg"));
                 |  }
                 |}""".trimMargin()
-        )
-        // no kotlin equivalent, since nested assignments do not exist
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .run()
-      .expect(
-        """
+                )
+                // no kotlin equivalent, since nested assignments do not exist
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .run()
+            .expect(
+                """
             |src/foo/Example.java:6: Warning: Using 'String#format' inside of 'Timber' [StringFormatInTimber]
             |    Timber.d(msg = String.format("msg"));
             |                   ~~~~~~~~~~~~~~~~~~~~
             |0 errors, 1 warnings""".trimMargin()
-      )
-  }
+            )
+    }
 
-  @Test
-  fun validStringFormatInCodeBlock() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun validStringFormatInCodeBlock() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |public class Example {
                 |  public void log() {
@@ -459,9 +459,9 @@ class WrongTimberUsageDetectorTest {
                 |    }
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |class Example {
                 |  fun log() {
@@ -470,79 +470,79 @@ class WrongTimberUsageDetectorTest {
                 |    }
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .run()
-      .expectClean()
-  }
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .run()
+            .expectClean()
+    }
 
-  @Test
-  fun validStringFormatInConstructorCall() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun validStringFormatInConstructorCall() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |public class Example {
                 |  public void log() {
                 |    new Exception(String.format("msg"));
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |class Example {
                 |  fun log() {
                 |    Exception(String.format("msg"))
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .run()
-      .expectClean()
-  }
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .run()
+            .expectClean()
+    }
 
-  @Test
-  fun validStringFormatInStaticArray() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun validStringFormatInStaticArray() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |public class Example {
                 |  static String[] X = { String.format("%s", 100) };
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |class Example {
                 |  companion object {
                 |    val X = arrayOf(String.format("%s", 100))
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .run()
-      .expectClean()
-  }
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .run()
+            .expectClean()
+    }
 
-  @Test
-  fun validStringFormatExtracted() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun validStringFormatExtracted() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
               |package foo;
               |import timber.log.Timber;
               |public class Example {
@@ -551,9 +551,9 @@ class WrongTimberUsageDetectorTest {
               |    Timber.d(message);
               |  }
               |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
               |package foo
               |import timber.log.Timber
               |class Example {
@@ -562,21 +562,21 @@ class WrongTimberUsageDetectorTest {
               |    Timber.d(message)
               |  }
               |}""".trimMargin()
-        ),
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .run()
-      .expectClean()
-  }
+                ),
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .run()
+            .expectClean()
+    }
 
-  @Test
-  fun throwableNotAtBeginning() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun throwableNotAtBeginning() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -585,9 +585,9 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d("%s", e);
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -596,14 +596,14 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d("%s", e)
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .skipTestModes(TestMode.WHITESPACE)
-      .run()
-      .expect(
-        """
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .skipTestModes(TestMode.WHITESPACE)
+            .run()
+            .expect(
+                """
             |src/foo/Example.java:6: Warning: Throwable should be first argument [ThrowableNotAtBeginning]
             |     Timber.d("%s", e);
             |     ~~~~~~~~~~~~~~~~~
@@ -611,9 +611,9 @@ class WrongTimberUsageDetectorTest {
             |     Timber.d("%s", e)
             |     ~~~~~~~~~~~~~~~~~
             |0 errors, 2 warnings""".trimMargin()
-      )
-      .expectFixDiffs(
-        """
+            )
+            .expectFixDiffs(
+                """
             |Fix for src/foo/Example.java line 6: Replace with e, "%s":
             |@@ -6 +6
             |-      Timber.d("%s", e);
@@ -623,16 +623,16 @@ class WrongTimberUsageDetectorTest {
             |-      Timber.d("%s", e)
             |+      Timber.d(e, "%s")
             |""".trimMargin()
-      )
-  }
+            )
+    }
 
-  @Test
-  fun stringConcatenationBothLiterals() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun stringConcatenationBothLiterals() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -640,9 +640,9 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d("foo" + "bar");
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -650,21 +650,21 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d("foo" + "bar")
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .run()
-      .expectClean()
-  }
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .run()
+            .expectClean()
+    }
 
-  @Test
-  fun stringConcatenationLeftLiteral() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun stringConcatenationLeftLiteral() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -673,9 +673,9 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(foo + "bar");
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -684,36 +684,36 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d("${"$"}{foo}bar")
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .skipTestModes(TestMode.PARENTHESIZED)
-      .run()
-      .expect(
-        """
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .skipTestModes(TestMode.PARENTHESIZED)
+            .run()
+            .expect(
+                """
             |src/foo/Example.java:6: Warning: Replace String concatenation with Timber's string formatting [BinaryOperationInTimber]
             |     Timber.d(foo + "bar");
             |              ~~~~~~~~~~~
             |0 errors, 1 warnings""".trimMargin()
-      )
-      .expectFixDiffs(
-        """
+            )
+            .expectFixDiffs(
+                """
             |Fix for src/foo/Example.java line 5: Replace with "%sbar", foo:
             |@@ -6 +6
             |-      Timber.d(foo + "bar");
             |+      Timber.d("%sbar", foo);
             |""".trimMargin()
-      )
-  }
+            )
+    }
 
-  @Test
-  fun stringConcatenationRightLiteral() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun stringConcatenationRightLiteral() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -722,9 +722,9 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d("foo" + bar);
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -733,36 +733,36 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d("foo${"$"}bar")
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .skipTestModes(TestMode.PARENTHESIZED)
-      .run()
-      .expect(
-        """
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .skipTestModes(TestMode.PARENTHESIZED)
+            .run()
+            .expect(
+                """
             |src/foo/Example.java:6: Warning: Replace String concatenation with Timber's string formatting [BinaryOperationInTimber]
             |     Timber.d("foo" + bar);
             |              ~~~~~~~~~~~
             |0 errors, 1 warnings""".trimMargin()
-      )
-      .expectFixDiffs(
-        """
+            )
+            .expectFixDiffs(
+                """
             |Fix for src/foo/Example.java line 5: Replace with "foo%s", bar:
             |@@ -6 +6
             |-      Timber.d("foo" + bar);
             |+      Timber.d("foo%s", bar);
             |""".trimMargin()
-      )
-  }
+            )
+    }
 
-  @Test
-  fun stringConcatenationBothVariables() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun stringConcatenationBothVariables() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -772,9 +772,9 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(foo + bar);
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -784,36 +784,36 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d("${"$"}{foo}${"$"}bar")
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .skipTestModes(TestMode.PARENTHESIZED)
-      .run()
-      .expect(
-        """
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .skipTestModes(TestMode.PARENTHESIZED)
+            .run()
+            .expect(
+                """
             |src/foo/Example.java:7: Warning: Replace String concatenation with Timber's string formatting [BinaryOperationInTimber]
             |     Timber.d(foo + bar);
             |              ~~~~~~~~~
             |0 errors, 1 warnings""".trimMargin()
-      )
-      .expectFixDiffs(
-        """
+            )
+            .expectFixDiffs(
+                """
             |Fix for src/foo/Example.java line 6: Replace with "%s%s", foo, bar:
             |@@ -7 +7
             |-      Timber.d(foo + bar);
             |+      Timber.d("%s%s", foo, bar);
             |""".trimMargin()
-      )
-  }
+            )
+    }
 
-  @Test
-  fun stringConcatenationInsideTernary() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun stringConcatenationInsideTernary() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -822,9 +822,9 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(true ? "Hello, " + s : "Bye");
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -833,28 +833,28 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(if(true) "Hello, ${"$"}{s}" else "Bye")
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .skipTestModes(TestMode.PARENTHESIZED)
-      .run()
-      .expect(
-        """
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .skipTestModes(TestMode.PARENTHESIZED)
+            .run()
+            .expect(
+                """
             |src/foo/Example.java:6: Warning: Replace String concatenation with Timber's string formatting [BinaryOperationInTimber]
             |     Timber.d(true ? "Hello, " + s : "Bye");
             |                     ~~~~~~~~~~~~~
             |0 errors, 1 warnings""".trimMargin()
-      )
-  }
+            )
+    }
 
-  @Test
-  fun tooManyFormatArgs() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun tooManyFormatArgs() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -862,9 +862,9 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d("%s %s", "arg1");
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -872,13 +872,13 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d("%s %s", "arg1")
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .run()
-      .expect(
-        """
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .run()
+            .expect(
+                """
             |src/foo/Example.java:5: Error: Wrong argument count, format string %s %s requires 2 but format call supplies 1 [TimberArgCount]
             |     Timber.d("%s %s", "arg1");
             |     ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -886,16 +886,16 @@ class WrongTimberUsageDetectorTest {
             |     Timber.d("%s %s", "arg1")
             |     ~~~~~~~~~~~~~~~~~~~~~~~~~
             |2 errors, 0 warnings""".trimMargin()
-      )
-  }
+            )
+    }
 
-  @Test
-  fun tooManyArgs() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun tooManyArgs() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -903,9 +903,9 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d("%s", "arg1", "arg2");
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -913,13 +913,13 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d("%s", "arg1", "arg2")
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .run()
-      .expect(
-        """
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .run()
+            .expect(
+                """
             |src/foo/Example.java:5: Error: Wrong argument count, format string %s requires 1 but format call supplies 2 [TimberArgCount]
             |     Timber.d("%s", "arg1", "arg2");
             |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -927,16 +927,16 @@ class WrongTimberUsageDetectorTest {
             |     Timber.d("%s", "arg1", "arg2")
             |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             |2 errors, 0 warnings""".trimMargin()
-      )
-  }
+            )
+    }
 
-  @Test
-  fun wrongArgTypes() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun wrongArgTypes() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -944,9 +944,9 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d("%d", "arg1");
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -954,13 +954,13 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d("%d", "arg1")
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .run()
-      .expect(
-        """
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .run()
+            .expect(
+                """
             |src/foo/Example.java:5: Error: Wrong argument type for formatting argument '#1' in %d: conversion is 'd', received String (argument #2 in method call) [TimberArgTypes]
             |     Timber.d("%d", "arg1");
             |                    ~~~~~~
@@ -968,16 +968,16 @@ class WrongTimberUsageDetectorTest {
             |     Timber.d("%d", "arg1")
             |                    ~~~~~~
             |2 errors, 0 warnings""".trimMargin()
-      )
-  }
+            )
+    }
 
-  @Test
-  fun tagTooLongLiteralOnly() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun tagTooLongLiteralOnly() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -985,9 +985,9 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.tag("abcdefghijklmnopqrstuvwx");
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -995,28 +995,28 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.tag("abcdefghijklmnopqrstuvwx")
                 |  }
                 |}""".trimMargin()
-        ),
-        manifest().minSdk(25)
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .run()
-      .expect(
-        """
+                ),
+                manifest().minSdk(25)
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .run()
+            .expect(
+                """
             |src/foo/Example.java:5: Error: The logging tag can be at most 23 characters, was 24 (abcdefghijklmnopqrstuvwx) [TimberTagLength]
             |     Timber.tag("abcdefghijklmnopqrstuvwx");
             |                ~~~~~~~~~~~~~~~~~~~~~~~~~~
             |1 errors, 0 warnings""".trimMargin()
-      )
-  }
+            )
+    }
 
-  @Test
-  fun tagTooLongLiteralOnlyBeforeApi26() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun tagTooLongLiteralOnlyBeforeApi26() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1024,9 +1024,9 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.tag("abcdefghijklmnopqrstuvwx");
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -1034,22 +1034,22 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.tag("abcdefghijklmnopqrstuvwx")
                 |  }
                 |}""".trimMargin()
-        ),
-        manifest().minSdk(26)
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .run()
-      .expectClean()
-  }
+                ),
+                manifest().minSdk(26)
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .run()
+            .expectClean()
+    }
 
-  @Test
-  fun tooManyFormatArgsInTag() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun tooManyFormatArgsInTag() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1057,9 +1057,9 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.tag("tag").d("%s %s", "arg1");
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -1067,13 +1067,13 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.tag("tag").d("%s %s", "arg1")
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .run()
-      .expect(
-        """
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .run()
+            .expect(
+                """
             |src/foo/Example.java:5: Error: Wrong argument count, format string %s %s requires 2 but format call supplies 1 [TimberArgCount]
             |     Timber.tag("tag").d("%s %s", "arg1");
             |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1081,16 +1081,16 @@ class WrongTimberUsageDetectorTest {
             |     Timber.tag("tag").d("%s %s", "arg1")
             |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             |2 errors, 0 warnings""".trimMargin()
-      )
-  }
+            )
+    }
 
-  @Test
-  fun tooManyArgsInTag() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun tooManyArgsInTag() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1098,9 +1098,9 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.tag("tag").d("%s", "arg1", "arg2");
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -1108,13 +1108,13 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.tag("tag").d("%s", "arg1", "arg2")
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .run()
-      .expect(
-        """
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .run()
+            .expect(
+                """
             |src/foo/Example.java:5: Error: Wrong argument count, format string %s requires 1 but format call supplies 2 [TimberArgCount]
             |     Timber.tag("tag").d("%s", "arg1", "arg2");
             |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1122,16 +1122,16 @@ class WrongTimberUsageDetectorTest {
             |     Timber.tag("tag").d("%s", "arg1", "arg2")
             |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             |2 errors, 0 warnings""".trimMargin()
-      )
-  }
+            )
+    }
 
-  @Test
-  fun wrongArgTypesInTag() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun wrongArgTypesInTag() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1139,9 +1139,9 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.tag("tag").d("%d", "arg1");
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -1149,13 +1149,13 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.tag("tag").d("%d", "arg1")
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .run()
-      .expect(
-        """
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .run()
+            .expect(
+                """
             |src/foo/Example.java:5: Error: Wrong argument type for formatting argument '#1' in %d: conversion is 'd', received String (argument #2 in method call) [TimberArgTypes]
             |     Timber.tag("tag").d("%d", "arg1");
             |                               ~~~~~~
@@ -1163,16 +1163,16 @@ class WrongTimberUsageDetectorTest {
             |     Timber.tag("tag").d("%d", "arg1")
             |                               ~~~~~~
             |2 errors, 0 warnings""".trimMargin()
-      )
-  }
+            )
+    }
 
-  @Test
-  fun exceptionLoggingUsingExceptionMessage() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun exceptionLoggingUsingExceptionMessage() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1181,9 +1181,9 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(e.getMessage());
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -1192,13 +1192,13 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(e.message)
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .run()
-      .expect(
-        """
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .run()
+            .expect(
+                """
             |src/foo/Example.java:6: Warning: Explicitly logging exception message is redundant [TimberExceptionLogging]
             |     Timber.d(e.getMessage());
             |     ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1206,9 +1206,9 @@ class WrongTimberUsageDetectorTest {
             |     Timber.d(e.message)
             |     ~~~~~~~~~~~~~~~~~~~
             |0 errors, 2 warnings""".trimMargin()
-      )
-      .expectFixDiffs(
-        """
+            )
+            .expectFixDiffs(
+                """
             |Fix for src/foo/Example.java line 6: Replace message with throwable:
             |@@ -6 +6
             |-      Timber.d(e.getMessage());
@@ -1218,16 +1218,16 @@ class WrongTimberUsageDetectorTest {
             |-      Timber.d(e.message)
             |+      Timber.d(e)
             |""".trimMargin()
-      )
-  }
+            )
+    }
 
-  @Test
-  fun exceptionLoggingUsingExceptionMessageArgument() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun exceptionLoggingUsingExceptionMessageArgument() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1236,9 +1236,9 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(e, e.getMessage());
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -1247,14 +1247,14 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(e, e.message)
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .skipTestModes(TestMode.REORDER_ARGUMENTS, TestMode.WHITESPACE)
-      .run()
-      .expect(
-        """
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .skipTestModes(TestMode.REORDER_ARGUMENTS, TestMode.WHITESPACE)
+            .run()
+            .expect(
+                """
             |src/foo/Example.java:6: Warning: Explicitly logging exception message is redundant [TimberExceptionLogging]
             |     Timber.d(e, e.getMessage());
             |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1262,9 +1262,9 @@ class WrongTimberUsageDetectorTest {
             |     Timber.d(e, e.message)
             |     ~~~~~~~~~~~~~~~~~~~~~~
             |0 errors, 2 warnings""".trimMargin()
-      )
-      .expectFixDiffs(
-        """
+            )
+            .expectFixDiffs(
+                """
             |Fix for src/foo/Example.java line 5: Remove redundant argument:
             |@@ -6 +6
             |-      Timber.d(e, e.getMessage());
@@ -1274,16 +1274,16 @@ class WrongTimberUsageDetectorTest {
             |-      Timber.d(e, e.message)
             |+      Timber.d(e)
             |""".trimMargin()
-      )
-  }
+            )
+    }
 
-  @Test
-  fun exceptionLoggingUsingVariable() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun exceptionLoggingUsingVariable() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1293,9 +1293,9 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(e, msg);
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -1305,22 +1305,22 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(e, msg)  
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .skipTestModes(TestMode.REORDER_ARGUMENTS)
-      .run()
-      .expectClean()
-  }
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .skipTestModes(TestMode.REORDER_ARGUMENTS)
+            .run()
+            .expectClean()
+    }
 
-  @Test
-  fun exceptionLoggingUsingParameter() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun exceptionLoggingUsingParameter() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1328,9 +1328,9 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(e, message);
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -1338,22 +1338,22 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(e, message)
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .skipTestModes(TestMode.REORDER_ARGUMENTS)
-      .run()
-      .expectClean()
-  }
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .skipTestModes(TestMode.REORDER_ARGUMENTS)
+            .run()
+            .expectClean()
+    }
 
-  @Test
-  fun exceptionLoggingUsingMethod() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun exceptionLoggingUsingMethod() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1364,9 +1364,9 @@ class WrongTimberUsageDetectorTest {
                 |    return "foo";
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -1377,22 +1377,22 @@ class WrongTimberUsageDetectorTest {
                 |     return "foo"
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .skipTestModes(TestMode.REORDER_ARGUMENTS)
-      .run()
-      .expectClean()
-  }
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .skipTestModes(TestMode.REORDER_ARGUMENTS)
+            .run()
+            .expectClean()
+    }
 
-  @Test
-  fun exceptionLoggingUsingNonFinalField() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun exceptionLoggingUsingNonFinalField() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1402,9 +1402,9 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(e, message);
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -1414,22 +1414,22 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(e, message)
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .skipTestModes(TestMode.REORDER_ARGUMENTS)
-      .run()
-      .expectClean()
-  }
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .skipTestModes(TestMode.REORDER_ARGUMENTS)
+            .run()
+            .expectClean()
+    }
 
-  @Test
-  fun exceptionLoggingUsingFinalField() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun exceptionLoggingUsingFinalField() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1439,9 +1439,9 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(e, message);
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -1451,22 +1451,22 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(e, message)
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .skipTestModes(TestMode.REORDER_ARGUMENTS)
-      .run()
-      .expectClean()
-  }
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .skipTestModes(TestMode.REORDER_ARGUMENTS)
+            .run()
+            .expectClean()
+    }
 
-  @Test
-  fun exceptionLoggingUsingEmptyStringMessage() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun exceptionLoggingUsingEmptyStringMessage() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1475,9 +1475,9 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(e, "");
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -1486,14 +1486,14 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(e, "")
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .skipTestModes(TestMode.REORDER_ARGUMENTS, TestMode.WHITESPACE)
-      .run()
-      .expect(
-        """
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .skipTestModes(TestMode.REORDER_ARGUMENTS, TestMode.WHITESPACE)
+            .run()
+            .expect(
+                """
             |src/foo/Example.java:6: Warning: Use single-argument log method instead of null/empty message [TimberExceptionLogging]
             |     Timber.d(e, "");
             |     ~~~~~~~~~~~~~~~
@@ -1501,9 +1501,9 @@ class WrongTimberUsageDetectorTest {
             |     Timber.d(e, "")
             |     ~~~~~~~~~~~~~~~
             |0 errors, 2 warnings""".trimMargin()
-      )
-      .expectFixDiffs(
-        """
+            )
+            .expectFixDiffs(
+                """
             |Fix for src/foo/Example.java line 6: Remove redundant argument:
             |@@ -6 +6
             |-      Timber.d(e, "");
@@ -1513,16 +1513,16 @@ class WrongTimberUsageDetectorTest {
             |-      Timber.d(e, "")
             |+      Timber.d(e)
             |""".trimMargin()
-      )
-  }
+            )
+    }
 
-  @Test
-  fun exceptionLoggingUsingNullMessage() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun exceptionLoggingUsingNullMessage() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1531,9 +1531,9 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(e, null);
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -1542,14 +1542,14 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(e, null)
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .skipTestModes(TestMode.REORDER_ARGUMENTS, TestMode.WHITESPACE)
-      .run()
-      .expect(
-        """
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .skipTestModes(TestMode.REORDER_ARGUMENTS, TestMode.WHITESPACE)
+            .run()
+            .expect(
+                """
             |src/foo/Example.java:6: Warning: Use single-argument log method instead of null/empty message [TimberExceptionLogging]
             |     Timber.d(e, null);
             |     ~~~~~~~~~~~~~~~~~
@@ -1557,9 +1557,9 @@ class WrongTimberUsageDetectorTest {
             |     Timber.d(e, null)
             |     ~~~~~~~~~~~~~~~~~
             |0 errors, 2 warnings""".trimMargin()
-      )
-      .expectFixDiffs(
-        """
+            )
+            .expectFixDiffs(
+                """
             |Fix for src/foo/Example.java line 6: Remove redundant argument:
             |@@ -6 +6
             |-      Timber.d(e, null);
@@ -1569,16 +1569,16 @@ class WrongTimberUsageDetectorTest {
             |-      Timber.d(e, null)
             |+      Timber.d(e)
             |""".trimMargin()
-      )
-  }
+            )
+    }
 
-  @Test
-  fun exceptionLoggingUsingValidMessage() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun exceptionLoggingUsingValidMessage() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1587,9 +1587,9 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(e, "Valid message");
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -1598,22 +1598,22 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(e, "Valid message")
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .skipTestModes(TestMode.REORDER_ARGUMENTS)
-      .run()
-      .expectClean()
-  }
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .skipTestModes(TestMode.REORDER_ARGUMENTS)
+            .run()
+            .expectClean()
+    }
 
-  @Test
-  fun dateFormatNotDisplayingWarning() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun dateFormatNotDisplayingWarning() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1621,9 +1621,9 @@ class WrongTimberUsageDetectorTest {
                 |    Timber.d("%tc", new java.util.Date());
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -1631,21 +1631,21 @@ class WrongTimberUsageDetectorTest {
                 |    Timber.d("%tc", java.util.Date())
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .run()
-      .expectClean()
-  }
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .run()
+            .expectClean()
+    }
 
-  @Test
-  fun systemTimeMillisValidMessage() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun systemTimeMillisValidMessage() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1653,9 +1653,9 @@ class WrongTimberUsageDetectorTest {
                 |    Timber.d("%tc", System.currentTimeMillis());
                 |  }
                 |}""".trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -1663,21 +1663,21 @@ class WrongTimberUsageDetectorTest {
                 |    Timber.d("%tc", System.currentTimeMillis())
                 |  }
                 |}""".trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .run()
-      .expectClean()
-  }
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .run()
+            .expectClean()
+    }
 
-  @Test
-  fun wrappedBooleanType() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun wrappedBooleanType() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1685,22 +1685,22 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d("%b", Boolean.valueOf(true));
                 |  }
                 |}""".trimMargin()
-        ),
-        // no kotlin equivalent, since primitive wrappers do not exist
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .run()
-      .expectClean()
-  }
+                ),
+                // no kotlin equivalent, since primitive wrappers do not exist
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .run()
+            .expectClean()
+    }
 
-  @Test
-  fun memberVariable() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        java(
-          """
+    @Test
+    fun memberVariable() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                java(
+                    """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1713,9 +1713,9 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}
                 """.trimMargin()
-        ),
-        kotlin(
-          """
+                ),
+                kotlin(
+                    """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -1728,21 +1728,21 @@ class WrongTimberUsageDetectorTest {
                 |  }
                 |}
                 """.trimMargin()
-        )
-      )
-      .allowClassNameClashes(true)
-      .issues(*issues)
-      .run()
-      .expectClean()
-  }
+                )
+            )
+            .allowClassNameClashes(true)
+            .issues(*issues)
+            .run()
+            .expectClean()
+    }
 
-  @Test
-  fun exceptionLoggingWithGuardedVariable() {
-    lint()
-      .files(
-        TIMBER_STUB,
-        kotlin(
-          """
+    @Test
+    fun exceptionLoggingWithGuardedVariable() {
+        lint()
+            .files(
+                TIMBER_STUB,
+                kotlin(
+                    """
               |package foo
               |import timber.log.Timber
               |import java.lang.Exception
@@ -1765,11 +1765,11 @@ class WrongTimberUsageDetectorTest {
               |  }
               |}
               """.trimMargin()
-        )
-      )
-      .issues(WrongTimberUsageDetector.ISSUE_EXCEPTION_LOGGING)
-      .run()
-      // We expect this code to be perfectly clean with NO warnings.
-      .expectClean()
-  }
+                )
+            )
+            .issues(WrongTimberUsageDetector.ISSUE_EXCEPTION_LOGGING)
+            .run()
+            // We expect this code to be perfectly clean with NO warnings.
+            .expectClean()
+    }
 }

--- a/timber-lint/src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt
+++ b/timber-lint/src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt
@@ -1425,4 +1425,38 @@ class WrongTimberUsageDetectorTest {
         .run()
         .expectClean()
   }
+
+    @Test fun exceptionLoggingWithGuardedVariable() {
+        lint()
+            .files(TIMBER_STUB,
+                kotlin("""
+              |package foo
+              |import timber.log.Timber
+              |import java.lang.Exception
+              |
+              |// This is a fake class just for our test.
+              |interface ApiResponse {
+              |  fun getErrorMessage(): String
+              |}
+              |
+              |class Example {
+              |  fun log(apiResponse: ApiResponse) {
+              |     // Get a message from a method, so the value isn't known at compile time.
+              |     val errorMessage = apiResponse.getErrorMessage()
+              |
+              |     // IMPORTANT: The check that proves the string is not empty.
+              |     if (errorMessage.isNotEmpty()) {
+              |       // This line should NOT cause a lint warning.
+              |       Timber.d(Exception("API Error"), errorMessage)
+              |     }
+              |  }
+              |}
+              """.trimMargin())
+            )
+            .issues(WrongTimberUsageDetector.ISSUE_EXCEPTION_LOGGING)
+            .run()
+            // We expect this code to be perfectly clean with NO warnings.
+            .expectClean()
+    }
+
 }

--- a/timber-lint/src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt
+++ b/timber-lint/src/test/java/timber/lint/WrongTimberUsageDetectorTest.kt
@@ -9,52 +9,62 @@ import org.junit.Test
 import timber.lint.WrongTimberUsageDetector.Companion.issues
 
 class WrongTimberUsageDetectorTest {
-  private val TIMBER_STUB = kotlin("""
+  private val TIMBER_STUB = kotlin(
+    """
       |package timber.log
       |class Timber private constructor() {
       |  private companion object {
       |    @JvmStatic fun d(message: String?, vararg args: Any?) {}
-      |    @JvmStatic fun d(t: Throwable?, message: String, vararg args: Any?) {}
+      |    @JvmStatic fun d(t: Throwable?, message: String?, vararg args: Any?) {}
       |    @JvmStatic fun tag(tag: String) = Tree()
       |  }
       |  open class Tree {
       |    open fun d(message: String?, vararg args: Any?) {}
       |    open fun d(t: Throwable?, message: String?, vararg args: Any?) {}
       |  }
-      |}""".trimMargin())
+      |}""".trimMargin()
+  )
 
-  @Test fun usingAndroidLogWithTwoArguments() {
+  @Test
+  fun usingAndroidLogWithTwoArguments() {
     lint()
-        .files(
-            java("""
+      .files(
+        java(
+          """
                 |package foo;
                 |import android.util.Log;
                 |public class Example {
                 |  public void log() {
                 |    Log.d("TAG", "msg");
                 |  }
-                |}""".trimMargin()),
-          kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import android.util.Log
                 |class Example {
                 |  fun log() {
                 |    Log.d("TAG", "msg")
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .run()
-        .expect("""
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .run()
+      .expect(
+        """
             |src/foo/Example.java:5: Warning: Using 'Log' instead of 'Timber' [LogNotTimber]
             |    Log.d("TAG", "msg");
             |    ~~~~~~~~~~~~~~~~~~~
             |src/foo/Example.kt:5: Warning: Using 'Log' instead of 'Timber' [LogNotTimber]
             |    Log.d("TAG", "msg")
             |    ~~~~~~~~~~~~~~~~~~~
-            |0 errors, 2 warnings""".trimMargin())
-        .expectFixDiffs("""
+            |0 errors, 2 warnings""".trimMargin()
+      )
+      .expectFixDiffs(
+        """
             |Fix for src/foo/Example.java line 5: Replace with Timber.tag("TAG").d("msg"):
             |@@ -5 +5
             |-     Log.d("TAG", "msg");
@@ -71,41 +81,50 @@ class WrongTimberUsageDetectorTest {
             |@@ -5 +5
             |-     Log.d("TAG", "msg")
             |+     Timber.d("msg")
-            |""".trimMargin())
+            |""".trimMargin()
+      )
   }
 
-  @Test fun usingAndroidLogWithThreeArguments() {
+  @Test
+  fun usingAndroidLogWithThreeArguments() {
     lint()
-        .files(
-            java("""
+      .files(
+        java(
+          """
                 |package foo;
                 |import android.util.Log;
                 |public class Example {
                 |  public void log() {
                 |    Log.d("TAG", "msg", new Exception());
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import android.util.Log
                 |class Example {
                 |  fun log() {
                 |    Log.d("TAG", "msg", Exception())
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .run()
-        .expect("""
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .run()
+      .expect(
+        """
             |src/foo/Example.java:5: Warning: Using 'Log' instead of 'Timber' [LogNotTimber]
             |    Log.d("TAG", "msg", new Exception());
             |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             |src/foo/Example.kt:5: Warning: Using 'Log' instead of 'Timber' [LogNotTimber]
             |    Log.d("TAG", "msg", Exception())
             |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            |0 errors, 2 warnings""".trimMargin())
-        .expectFixDiffs("""
+            |0 errors, 2 warnings""".trimMargin()
+      )
+      .expectFixDiffs(
+        """
             |Fix for src/foo/Example.java line 5: Replace with Timber.tag("TAG").d(new Exception(), "msg"):
             |@@ -5 +5
             |-     Log.d("TAG", "msg", new Exception());
@@ -122,39 +141,48 @@ class WrongTimberUsageDetectorTest {
             |@@ -5 +5
             |-     Log.d("TAG", "msg", Exception())
             |+     Timber.d(Exception(), "msg")
-            |""".trimMargin())
+            |""".trimMargin()
+      )
   }
 
-  @Test fun usingFullyQualifiedAndroidLogWithTwoArguments() {
+  @Test
+  fun usingFullyQualifiedAndroidLogWithTwoArguments() {
     lint()
-        .files(
-            java("""
+      .files(
+        java(
+          """
                 |package foo;
                 |public class Example {
                 |  public void log() {
                 |    android.util.Log.d("TAG", "msg");
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |class Example {
                 |  fun log() {
                 |    android.util.Log.d("TAG", "msg")
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .run()
-        .expect("""
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .run()
+      .expect(
+        """
             |src/foo/Example.java:4: Warning: Using 'Log' instead of 'Timber' [LogNotTimber]
             |    android.util.Log.d("TAG", "msg");
             |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             |src/foo/Example.kt:4: Warning: Using 'Log' instead of 'Timber' [LogNotTimber]
             |    android.util.Log.d("TAG", "msg")
             |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            |0 errors, 2 warnings""".trimMargin())
-        .expectFixDiffs("""
+            |0 errors, 2 warnings""".trimMargin()
+      )
+      .expectFixDiffs(
+        """
             |Fix for src/foo/Example.java line 4: Replace with Timber.tag("TAG").d("msg"):
             |@@ -4 +4
             |-     android.util.Log.d("TAG", "msg");
@@ -171,39 +199,48 @@ class WrongTimberUsageDetectorTest {
             |@@ -4 +4
             |-     android.util.Log.d("TAG", "msg")
             |+     Timber.d("msg")
-            |""".trimMargin())
+            |""".trimMargin()
+      )
   }
 
-  @Test fun usingFullyQualifiedAndroidLogWithThreeArguments() {
+  @Test
+  fun usingFullyQualifiedAndroidLogWithThreeArguments() {
     lint()
-        .files(
-            java("""
+      .files(
+        java(
+          """
                 |package foo;
                 |public class Example {
                 |  public void log() {
                 |    android.util.Log.d("TAG", "msg", new Exception());
                 |  }
-                |}""".trimMargin()),
-          kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |class Example {
                 |  fun log() {
                 |    android.util.Log.d("TAG", "msg", Exception())
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .run()
-        .expect("""
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .run()
+      .expect(
+        """
             |src/foo/Example.java:4: Warning: Using 'Log' instead of 'Timber' [LogNotTimber]
             |    android.util.Log.d("TAG", "msg", new Exception());
             |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             |src/foo/Example.kt:4: Warning: Using 'Log' instead of 'Timber' [LogNotTimber]
             |    android.util.Log.d("TAG", "msg", Exception())
             |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            |0 errors, 2 warnings""".trimMargin())
-        .expectFixDiffs("""
+            |0 errors, 2 warnings""".trimMargin()
+      )
+      .expectFixDiffs(
+        """
             |Fix for src/foo/Example.java line 4: Replace with Timber.tag("TAG").d(new Exception(), "msg"):
             |@@ -4 +4
             |-     android.util.Log.d("TAG", "msg", new Exception());
@@ -220,42 +257,52 @@ class WrongTimberUsageDetectorTest {
             |@@ -4 +4
             |-     android.util.Log.d("TAG", "msg", Exception())
             |+     Timber.d(Exception(), "msg")
-            |""".trimMargin())
+            |""".trimMargin()
+      )
   }
 
-  @Test fun innerStringFormat() {
+  @Test
+  fun innerStringFormat() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
                 |  public void log() {
                 |     Timber.d(String.format("%s", "arg1"));
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
                 |  fun log() {
                 |     Timber.d(String.format("%s", "arg1"))
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .skipTestModes(TestMode.WHITESPACE)
-        .run()
-        .expect("""
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .skipTestModes(TestMode.WHITESPACE)
+      .run()
+      .expect(
+        """
             |src/foo/Example.java:5: Warning: Using 'String#format' inside of 'Timber' [StringFormatInTimber]
             |     Timber.d(String.format("%s", "arg1"));
             |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~
             |src/foo/Example.kt:5: Warning: Using 'String#format' inside of 'Timber' [StringFormatInTimber]
             |     Timber.d(String.format("%s", "arg1"))
             |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            |0 errors, 2 warnings""".trimMargin())
-        .expectFixDiffs("""
+            |0 errors, 2 warnings""".trimMargin()
+      )
+      .expectFixDiffs(
+        """
             |Fix for src/foo/Example.java line 5: Remove String.format(...):
             |@@ -5 +5
             |-      Timber.d(String.format("%s", "arg1"));
@@ -264,13 +311,17 @@ class WrongTimberUsageDetectorTest {
             |@@ -5 +5
             |-      Timber.d(String.format("%s", "arg1"))
             |+      Timber.d("%s", "arg1")
-            |""".trimMargin())
+            |""".trimMargin()
+      )
   }
 
-  @Test fun innerStringFormatWithStaticImport() {
+  @Test
+  fun innerStringFormatWithStaticImport() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |import static java.lang.String.format;
@@ -278,8 +329,10 @@ class WrongTimberUsageDetectorTest {
                 |  public void log() {
                 |     Timber.d(format("%s", "arg1"));
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |import java.lang.String.format
@@ -287,21 +340,25 @@ class WrongTimberUsageDetectorTest {
                 |  fun log() {
                 |     Timber.d(format("%s", "arg1"))
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .skipTestModes(TestMode.PARENTHESIZED, TestMode.WHITESPACE)
-        .run()
-        .expect("""
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .skipTestModes(TestMode.PARENTHESIZED, TestMode.WHITESPACE)
+      .run()
+      .expect(
+        """
             |src/foo/Example.java:6: Warning: Using 'String#format' inside of 'Timber' [StringFormatInTimber]
             |     Timber.d(format("%s", "arg1"));
             |              ~~~~~~~~~~~~~~~~~~~~
             |src/foo/Example.kt:6: Warning: Using 'String#format' inside of 'Timber' [StringFormatInTimber]
             |     Timber.d(format("%s", "arg1"))
             |              ~~~~~~~~~~~~~~~~~~~~
-            |0 errors, 2 warnings""".trimMargin())
-        .expectFixDiffs("""
+            |0 errors, 2 warnings""".trimMargin()
+      )
+      .expectFixDiffs(
+        """
             |Fix for src/foo/Example.java line 6: Remove String.format(...):
             |@@ -6 +6
             |-      Timber.d(format("%s", "arg1"));
@@ -310,13 +367,17 @@ class WrongTimberUsageDetectorTest {
             |@@ -6 +6
             |-      Timber.d(format("%s", "arg1"))
             |+      Timber.d("%s", "arg1")
-            |""".trimMargin())
+            |""".trimMargin()
+      )
   }
 
-  @Test fun innerStringFormatInNestedMethods() {
+  @Test
+  fun innerStringFormatInNestedMethods() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -324,8 +385,10 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(id(String.format("%s", "arg1")));
                 |  }
                 |  private String id(String s) { return s; }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -333,25 +396,31 @@ class WrongTimberUsageDetectorTest {
                 |     Timber.d(id(String.format("%s", "arg1")))
                 |  }
                 |  private fun id(s: String): String { return s }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .run()
-        .expect("""
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .run()
+      .expect(
+        """
             |src/foo/Example.java:5: Warning: Using 'String#format' inside of 'Timber' [StringFormatInTimber]
             |     Timber.d(id(String.format("%s", "arg1")));
             |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
             |src/foo/Example.kt:5: Warning: Using 'String#format' inside of 'Timber' [StringFormatInTimber]
             |     Timber.d(id(String.format("%s", "arg1")))
             |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            |0 errors, 2 warnings""".trimMargin())
+            |0 errors, 2 warnings""".trimMargin()
+      )
   }
 
-  @Test fun innerStringFormatInNestedAssignment() {
+  @Test
+  fun innerStringFormatInNestedAssignment() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -359,23 +428,29 @@ class WrongTimberUsageDetectorTest {
                 |    String msg = null;
                 |    Timber.d(msg = String.format("msg"));
                 |  }
-                |}""".trimMargin())
-          // no kotlin equivalent, since nested assignments do not exist
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .run()
-        .expect("""
+        // no kotlin equivalent, since nested assignments do not exist
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .run()
+      .expect(
+        """
             |src/foo/Example.java:6: Warning: Using 'String#format' inside of 'Timber' [StringFormatInTimber]
             |    Timber.d(msg = String.format("msg"));
             |                   ~~~~~~~~~~~~~~~~~~~~
-            |0 errors, 1 warnings""".trimMargin())
+            |0 errors, 1 warnings""".trimMargin()
+      )
   }
 
-  @Test fun validStringFormatInCodeBlock() {
+  @Test
+  fun validStringFormatInCodeBlock() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |public class Example {
                 |  public void log() {
@@ -383,8 +458,10 @@ class WrongTimberUsageDetectorTest {
                 |      String name = String.format("msg");
                 |    }
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |class Example {
                 |  fun log() {
@@ -392,81 +469,8 @@ class WrongTimberUsageDetectorTest {
                 |      val name = String.format("msg")
                 |    }
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .run()
-        .expectClean()
-  }
-
-  @Test fun validStringFormatInConstructorCall() {
-    lint()
-        .files(TIMBER_STUB,
-            java("""
-                |package foo;
-                |public class Example {
-                |  public void log() {
-                |    new Exception(String.format("msg"));
-                |  }
-                |}""".trimMargin()),
-          kotlin("""
-                |package foo
-                |class Example {
-                |  fun log() {
-                |    Exception(String.format("msg"))
-                |  }
-                |}""".trimMargin())
-        )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .run()
-        .expectClean()
-  }
-
-  @Test fun validStringFormatInStaticArray() {
-    lint()
-        .files(TIMBER_STUB,
-            java("""
-                |package foo;
-                |public class Example {
-                |  static String[] X = { String.format("%s", 100) };
-                |}""".trimMargin()),
-           kotlin("""
-                |package foo
-                |class Example {
-                |  companion object {
-                |    val X = arrayOf(String.format("%s", 100))
-                |  }
-                |}""".trimMargin())
-        )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .run()
-        .expectClean()
-  }
-
-  @Test fun validStringFormatExtracted() {
-    lint()
-      .files(TIMBER_STUB,
-          java("""
-              |package foo;
-              |import timber.log.Timber;
-              |public class Example {
-              |  public void log() {
-              |    String message = String.format("%s", "foo");
-              |    Timber.d(message);
-              |  }
-              |}""".trimMargin()),
-          kotlin("""
-              |package foo
-              |import timber.log.Timber
-              |class Example {
-              |  fun log() {
-              |    val message = String.format("%s", "foo")
-              |    Timber.d(message)
-              |  }
-              |}""".trimMargin()),
       )
       .allowClassNameClashes(true)
       .issues(*issues)
@@ -474,10 +478,105 @@ class WrongTimberUsageDetectorTest {
       .expectClean()
   }
 
-  @Test fun throwableNotAtBeginning() {
+  @Test
+  fun validStringFormatInConstructorCall() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
+                |package foo;
+                |public class Example {
+                |  public void log() {
+                |    new Exception(String.format("msg"));
+                |  }
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
+                |package foo
+                |class Example {
+                |  fun log() {
+                |    Exception(String.format("msg"))
+                |  }
+                |}""".trimMargin()
+        )
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun validStringFormatInStaticArray() {
+    lint()
+      .files(
+        TIMBER_STUB,
+        java(
+          """
+                |package foo;
+                |public class Example {
+                |  static String[] X = { String.format("%s", 100) };
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
+                |package foo
+                |class Example {
+                |  companion object {
+                |    val X = arrayOf(String.format("%s", 100))
+                |  }
+                |}""".trimMargin()
+        )
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun validStringFormatExtracted() {
+    lint()
+      .files(
+        TIMBER_STUB,
+        java(
+          """
+              |package foo;
+              |import timber.log.Timber;
+              |public class Example {
+              |  public void log() {
+              |    String message = String.format("%s", "foo");
+              |    Timber.d(message);
+              |  }
+              |}""".trimMargin()
+        ),
+        kotlin(
+          """
+              |package foo
+              |import timber.log.Timber
+              |class Example {
+              |  fun log() {
+              |    val message = String.format("%s", "foo")
+              |    Timber.d(message)
+              |  }
+              |}""".trimMargin()
+        ),
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun throwableNotAtBeginning() {
+    lint()
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -485,8 +584,10 @@ class WrongTimberUsageDetectorTest {
                 |     Exception e = new Exception();
                 |     Timber.d("%s", e);
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -494,21 +595,25 @@ class WrongTimberUsageDetectorTest {
                 |     val e = Exception()
                 |     Timber.d("%s", e)
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .skipTestModes(TestMode.WHITESPACE)
-        .run()
-        .expect("""
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .skipTestModes(TestMode.WHITESPACE)
+      .run()
+      .expect(
+        """
             |src/foo/Example.java:6: Warning: Throwable should be first argument [ThrowableNotAtBeginning]
             |     Timber.d("%s", e);
             |     ~~~~~~~~~~~~~~~~~
             |src/foo/Example.kt:6: Warning: Throwable should be first argument [ThrowableNotAtBeginning]
             |     Timber.d("%s", e)
             |     ~~~~~~~~~~~~~~~~~
-            |0 errors, 2 warnings""".trimMargin())
-        .expectFixDiffs("""
+            |0 errors, 2 warnings""".trimMargin()
+      )
+      .expectFixDiffs(
+        """
             |Fix for src/foo/Example.java line 6: Replace with e, "%s":
             |@@ -6 +6
             |-      Timber.d("%s", e);
@@ -517,39 +622,49 @@ class WrongTimberUsageDetectorTest {
             |@@ -6 +6
             |-      Timber.d("%s", e)
             |+      Timber.d(e, "%s")
-            |""".trimMargin())
+            |""".trimMargin()
+      )
   }
 
-  @Test fun stringConcatenationBothLiterals() {
+  @Test
+  fun stringConcatenationBothLiterals() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
                 |  public void log() {
                 |     Timber.d("foo" + "bar");
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
                 |  fun log() {
                 |     Timber.d("foo" + "bar")
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .run()
-        .expectClean()
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .run()
+      .expectClean()
   }
 
-  @Test fun stringConcatenationLeftLiteral() {
+  @Test
+  fun stringConcatenationLeftLiteral() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -557,8 +672,10 @@ class WrongTimberUsageDetectorTest {
                 |     String foo = "foo";
                 |     Timber.d(foo + "bar");
                 |  }
-                |}""".trimMargin()),
-          kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -566,29 +683,37 @@ class WrongTimberUsageDetectorTest {
                 |     val foo = "foo"
                 |     Timber.d("${"$"}{foo}bar")
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .skipTestModes(TestMode.PARENTHESIZED)
-        .run()
-        .expect("""
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .skipTestModes(TestMode.PARENTHESIZED)
+      .run()
+      .expect(
+        """
             |src/foo/Example.java:6: Warning: Replace String concatenation with Timber's string formatting [BinaryOperationInTimber]
             |     Timber.d(foo + "bar");
             |              ~~~~~~~~~~~
-            |0 errors, 1 warnings""".trimMargin())
-        .expectFixDiffs("""
+            |0 errors, 1 warnings""".trimMargin()
+      )
+      .expectFixDiffs(
+        """
             |Fix for src/foo/Example.java line 5: Replace with "%sbar", foo:
             |@@ -6 +6
             |-      Timber.d(foo + "bar");
             |+      Timber.d("%sbar", foo);
-            |""".trimMargin())
+            |""".trimMargin()
+      )
   }
 
-  @Test fun stringConcatenationRightLiteral() {
+  @Test
+  fun stringConcatenationRightLiteral() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -596,8 +721,10 @@ class WrongTimberUsageDetectorTest {
                 |     String bar = "bar";
                 |     Timber.d("foo" + bar);
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -605,29 +732,37 @@ class WrongTimberUsageDetectorTest {
                 |     val bar = "bar"
                 |     Timber.d("foo${"$"}bar")
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .skipTestModes(TestMode.PARENTHESIZED)
-        .run()
-        .expect("""
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .skipTestModes(TestMode.PARENTHESIZED)
+      .run()
+      .expect(
+        """
             |src/foo/Example.java:6: Warning: Replace String concatenation with Timber's string formatting [BinaryOperationInTimber]
             |     Timber.d("foo" + bar);
             |              ~~~~~~~~~~~
-            |0 errors, 1 warnings""".trimMargin())
-        .expectFixDiffs("""
+            |0 errors, 1 warnings""".trimMargin()
+      )
+      .expectFixDiffs(
+        """
             |Fix for src/foo/Example.java line 5: Replace with "foo%s", bar:
             |@@ -6 +6
             |-      Timber.d("foo" + bar);
             |+      Timber.d("foo%s", bar);
-            |""".trimMargin())
+            |""".trimMargin()
+      )
   }
 
-  @Test fun stringConcatenationBothVariables() {
+  @Test
+  fun stringConcatenationBothVariables() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -636,39 +771,49 @@ class WrongTimberUsageDetectorTest {
                 |     String bar = "bar";
                 |     Timber.d(foo + bar);
                 |  }
-                |}""".trimMargin()),
-          kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
                 |  fun log() {
                 |     val foo = "foo"
                 |     val bar = "bar"
-                |     Timber.d("${"$"}foo${"$"}bar")
+                |     Timber.d("${"$"}{foo}${"$"}bar")
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .skipTestModes(TestMode.PARENTHESIZED)
-        .run()
-        .expect("""
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .skipTestModes(TestMode.PARENTHESIZED)
+      .run()
+      .expect(
+        """
             |src/foo/Example.java:7: Warning: Replace String concatenation with Timber's string formatting [BinaryOperationInTimber]
             |     Timber.d(foo + bar);
             |              ~~~~~~~~~
-            |0 errors, 1 warnings""".trimMargin())
-        .expectFixDiffs("""
+            |0 errors, 1 warnings""".trimMargin()
+      )
+      .expectFixDiffs(
+        """
             |Fix for src/foo/Example.java line 6: Replace with "%s%s", foo, bar:
             |@@ -7 +7
             |-      Timber.d(foo + bar);
             |+      Timber.d("%s%s", foo, bar);
-            |""".trimMargin())
+            |""".trimMargin()
+      )
   }
 
-  @Test fun stringConcatenationInsideTernary() {
+  @Test
+  fun stringConcatenationInsideTernary() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -676,288 +821,358 @@ class WrongTimberUsageDetectorTest {
                 |     String s = "world!";
                 |     Timber.d(true ? "Hello, " + s : "Bye");
                 |  }
-                |}""".trimMargin()),
-          kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
                 |  fun log() {
                 |     val s = "world!"
-                |     Timber.d(if(true) "Hello, ${"$"}s" else "Bye")
+                |     Timber.d(if(true) "Hello, ${"$"}{s}" else "Bye")
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .skipTestModes(TestMode.PARENTHESIZED)
-        .run()
-        .expect("""
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .skipTestModes(TestMode.PARENTHESIZED)
+      .run()
+      .expect(
+        """
             |src/foo/Example.java:6: Warning: Replace String concatenation with Timber's string formatting [BinaryOperationInTimber]
             |     Timber.d(true ? "Hello, " + s : "Bye");
             |                     ~~~~~~~~~~~~~
-            |0 errors, 1 warnings""".trimMargin())
+            |0 errors, 1 warnings""".trimMargin()
+      )
   }
 
-  @Test fun tooManyFormatArgs() {
+  @Test
+  fun tooManyFormatArgs() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
                 |  public void log() {
                 |     Timber.d("%s %s", "arg1");
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
                 |  fun log() {
                 |     Timber.d("%s %s", "arg1")
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .run()
-        .expect("""
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .run()
+      .expect(
+        """
             |src/foo/Example.java:5: Error: Wrong argument count, format string %s %s requires 2 but format call supplies 1 [TimberArgCount]
             |     Timber.d("%s %s", "arg1");
             |     ~~~~~~~~~~~~~~~~~~~~~~~~~
             |src/foo/Example.kt:5: Error: Wrong argument count, format string %s %s requires 2 but format call supplies 1 [TimberArgCount]
             |     Timber.d("%s %s", "arg1")
             |     ~~~~~~~~~~~~~~~~~~~~~~~~~
-            |2 errors, 0 warnings""".trimMargin())
+            |2 errors, 0 warnings""".trimMargin()
+      )
   }
 
-  @Test fun tooManyArgs() {
+  @Test
+  fun tooManyArgs() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
                 |  public void log() {
                 |     Timber.d("%s", "arg1", "arg2");
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
                 |  fun log() {
                 |     Timber.d("%s", "arg1", "arg2")
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .run()
-        .expect("""
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .run()
+      .expect(
+        """
             |src/foo/Example.java:5: Error: Wrong argument count, format string %s requires 1 but format call supplies 2 [TimberArgCount]
             |     Timber.d("%s", "arg1", "arg2");
             |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             |src/foo/Example.kt:5: Error: Wrong argument count, format string %s requires 1 but format call supplies 2 [TimberArgCount]
             |     Timber.d("%s", "arg1", "arg2")
             |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            |2 errors, 0 warnings""".trimMargin())
+            |2 errors, 0 warnings""".trimMargin()
+      )
   }
 
-  @Test fun wrongArgTypes() {
+  @Test
+  fun wrongArgTypes() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
                 |  public void log() {
                 |     Timber.d("%d", "arg1");
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
                 |  fun log() {
                 |     Timber.d("%d", "arg1")
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .run()
-        .expect("""
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .run()
+      .expect(
+        """
             |src/foo/Example.java:5: Error: Wrong argument type for formatting argument '#1' in %d: conversion is 'd', received String (argument #2 in method call) [TimberArgTypes]
             |     Timber.d("%d", "arg1");
             |                    ~~~~~~
             |src/foo/Example.kt:5: Error: Wrong argument type for formatting argument '#1' in %d: conversion is 'd', received String (argument #2 in method call) [TimberArgTypes]
             |     Timber.d("%d", "arg1")
             |                    ~~~~~~
-            |2 errors, 0 warnings""".trimMargin())
+            |2 errors, 0 warnings""".trimMargin()
+      )
   }
 
-  @Test fun tagTooLongLiteralOnly() {
+  @Test
+  fun tagTooLongLiteralOnly() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
                 |  public void log() {
                 |     Timber.tag("abcdefghijklmnopqrstuvwx");
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
                 |  fun log() {
                 |     Timber.tag("abcdefghijklmnopqrstuvwx")
                 |  }
-                |}""".trimMargin()),
-                manifest().minSdk(25)
-        )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .run()
-        .expect("""
+                |}""".trimMargin()
+        ),
+        manifest().minSdk(25)
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .run()
+      .expect(
+        """
             |src/foo/Example.java:5: Error: The logging tag can be at most 23 characters, was 24 (abcdefghijklmnopqrstuvwx) [TimberTagLength]
             |     Timber.tag("abcdefghijklmnopqrstuvwx");
             |                ~~~~~~~~~~~~~~~~~~~~~~~~~~
-            |1 errors, 0 warnings""".trimMargin())
+            |1 errors, 0 warnings""".trimMargin()
+      )
   }
 
-  @Test fun tagTooLongLiteralOnlyBeforeApi26() {
+  @Test
+  fun tagTooLongLiteralOnlyBeforeApi26() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
                 |  public void log() {
                 |     Timber.tag("abcdefghijklmnopqrstuvwx");
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
                 |  fun log() {
                 |     Timber.tag("abcdefghijklmnopqrstuvwx")
                 |  }
-                |}""".trimMargin()),
-            manifest().minSdk(26)
-        )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .run()
-        .expectClean()
+                |}""".trimMargin()
+        ),
+        manifest().minSdk(26)
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .run()
+      .expectClean()
   }
 
-  @Test fun tooManyFormatArgsInTag() {
+  @Test
+  fun tooManyFormatArgsInTag() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
                 |  public void log() {
                 |     Timber.tag("tag").d("%s %s", "arg1");
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
                 |  fun log() {
                 |     Timber.tag("tag").d("%s %s", "arg1")
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .run()
-        .expect("""
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .run()
+      .expect(
+        """
             |src/foo/Example.java:5: Error: Wrong argument count, format string %s %s requires 2 but format call supplies 1 [TimberArgCount]
             |     Timber.tag("tag").d("%s %s", "arg1");
             |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             |src/foo/Example.kt:5: Error: Wrong argument count, format string %s %s requires 2 but format call supplies 1 [TimberArgCount]
             |     Timber.tag("tag").d("%s %s", "arg1")
             |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            |2 errors, 0 warnings""".trimMargin())
+            |2 errors, 0 warnings""".trimMargin()
+      )
   }
 
-  @Test fun tooManyArgsInTag() {
+  @Test
+  fun tooManyArgsInTag() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
                 |  public void log() {
                 |     Timber.tag("tag").d("%s", "arg1", "arg2");
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
                 |  fun log() {
                 |     Timber.tag("tag").d("%s", "arg1", "arg2")
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .run()
-        .expect("""
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .run()
+      .expect(
+        """
             |src/foo/Example.java:5: Error: Wrong argument count, format string %s requires 1 but format call supplies 2 [TimberArgCount]
             |     Timber.tag("tag").d("%s", "arg1", "arg2");
             |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             |src/foo/Example.kt:5: Error: Wrong argument count, format string %s requires 1 but format call supplies 2 [TimberArgCount]
             |     Timber.tag("tag").d("%s", "arg1", "arg2")
             |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            |2 errors, 0 warnings""".trimMargin())
+            |2 errors, 0 warnings""".trimMargin()
+      )
   }
 
-  @Test fun wrongArgTypesInTag() {
+  @Test
+  fun wrongArgTypesInTag() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
                 |  public void log() {
                 |     Timber.tag("tag").d("%d", "arg1");
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
                 |  fun log() {
                 |     Timber.tag("tag").d("%d", "arg1")
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .run()
-        .expect("""
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .run()
+      .expect(
+        """
             |src/foo/Example.java:5: Error: Wrong argument type for formatting argument '#1' in %d: conversion is 'd', received String (argument #2 in method call) [TimberArgTypes]
             |     Timber.tag("tag").d("%d", "arg1");
             |                               ~~~~~~
             |src/foo/Example.kt:5: Error: Wrong argument type for formatting argument '#1' in %d: conversion is 'd', received String (argument #2 in method call) [TimberArgTypes]
             |     Timber.tag("tag").d("%d", "arg1")
             |                               ~~~~~~
-            |2 errors, 0 warnings""".trimMargin())
+            |2 errors, 0 warnings""".trimMargin()
+      )
   }
 
-  @Test fun exceptionLoggingUsingExceptionMessage() {
+  @Test
+  fun exceptionLoggingUsingExceptionMessage() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -965,8 +1180,10 @@ class WrongTimberUsageDetectorTest {
                 |     Exception e = new Exception();
                 |     Timber.d(e.getMessage());
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -974,20 +1191,24 @@ class WrongTimberUsageDetectorTest {
                 |     val e = Exception()
                 |     Timber.d(e.message)
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .run()
-        .expect("""
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .run()
+      .expect(
+        """
             |src/foo/Example.java:6: Warning: Explicitly logging exception message is redundant [TimberExceptionLogging]
             |     Timber.d(e.getMessage());
             |     ~~~~~~~~~~~~~~~~~~~~~~~~
             |src/foo/Example.kt:6: Warning: Explicitly logging exception message is redundant [TimberExceptionLogging]
             |     Timber.d(e.message)
             |     ~~~~~~~~~~~~~~~~~~~
-            |0 errors, 2 warnings""".trimMargin())
-        .expectFixDiffs("""
+            |0 errors, 2 warnings""".trimMargin()
+      )
+      .expectFixDiffs(
+        """
             |Fix for src/foo/Example.java line 6: Replace message with throwable:
             |@@ -6 +6
             |-      Timber.d(e.getMessage());
@@ -996,13 +1217,17 @@ class WrongTimberUsageDetectorTest {
             |@@ -6 +6
             |-      Timber.d(e.message)
             |+      Timber.d(e)
-            |""".trimMargin())
+            |""".trimMargin()
+      )
   }
 
-  @Test fun exceptionLoggingUsingExceptionMessageArgument() {
+  @Test
+  fun exceptionLoggingUsingExceptionMessageArgument() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1010,8 +1235,10 @@ class WrongTimberUsageDetectorTest {
                 |     Exception e = new Exception();
                 |     Timber.d(e, e.getMessage());
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -1019,21 +1246,25 @@ class WrongTimberUsageDetectorTest {
                 |     val e = Exception()
                 |     Timber.d(e, e.message)
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .skipTestModes(TestMode.REORDER_ARGUMENTS, TestMode.WHITESPACE)
-        .run()
-        .expect("""
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .skipTestModes(TestMode.REORDER_ARGUMENTS, TestMode.WHITESPACE)
+      .run()
+      .expect(
+        """
             |src/foo/Example.java:6: Warning: Explicitly logging exception message is redundant [TimberExceptionLogging]
             |     Timber.d(e, e.getMessage());
             |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
             |src/foo/Example.kt:6: Warning: Explicitly logging exception message is redundant [TimberExceptionLogging]
             |     Timber.d(e, e.message)
             |     ~~~~~~~~~~~~~~~~~~~~~~
-            |0 errors, 2 warnings""".trimMargin())
-        .expectFixDiffs("""
+            |0 errors, 2 warnings""".trimMargin()
+      )
+      .expectFixDiffs(
+        """
             |Fix for src/foo/Example.java line 5: Remove redundant argument:
             |@@ -6 +6
             |-      Timber.d(e, e.getMessage());
@@ -1042,13 +1273,17 @@ class WrongTimberUsageDetectorTest {
             |@@ -6 +6
             |-      Timber.d(e, e.message)
             |+      Timber.d(e)
-            |""".trimMargin())
+            |""".trimMargin()
+      )
   }
 
-  @Test fun exceptionLoggingUsingVariable() {
+  @Test
+  fun exceptionLoggingUsingVariable() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1057,8 +1292,10 @@ class WrongTimberUsageDetectorTest {
                 |     Exception e = new Exception();
                 |     Timber.d(e, msg);
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -1067,46 +1304,56 @@ class WrongTimberUsageDetectorTest {
                 |     val e = Exception()
                 |     Timber.d(e, msg)  
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .skipTestModes(TestMode.REORDER_ARGUMENTS)
-        .run()
-        .expectClean()
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .skipTestModes(TestMode.REORDER_ARGUMENTS)
+      .run()
+      .expectClean()
   }
 
-  @Test fun exceptionLoggingUsingParameter() {
+  @Test
+  fun exceptionLoggingUsingParameter() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
                 |  public void log(Exception e, String message) {
                 |     Timber.d(e, message);
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
                 |  fun log(e: Exception, message: String) {
                 |     Timber.d(e, message)
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .skipTestModes(TestMode.REORDER_ARGUMENTS)
-        .run()
-        .expectClean()
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .skipTestModes(TestMode.REORDER_ARGUMENTS)
+      .run()
+      .expectClean()
   }
 
-  @Test fun exceptionLoggingUsingMethod() {
+  @Test
+  fun exceptionLoggingUsingMethod() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1116,8 +1363,10 @@ class WrongTimberUsageDetectorTest {
                 |  private String method() {
                 |    return "foo";
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -1127,19 +1376,23 @@ class WrongTimberUsageDetectorTest {
                 |  private fun method(): String {
                 |     return "foo"
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .skipTestModes(TestMode.REORDER_ARGUMENTS)
-        .run()
-        .expectClean()
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .skipTestModes(TestMode.REORDER_ARGUMENTS)
+      .run()
+      .expectClean()
   }
 
-  @Test fun exceptionLoggingUsingNonFinalField() {
+  @Test
+  fun exceptionLoggingUsingNonFinalField() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1148,8 +1401,10 @@ class WrongTimberUsageDetectorTest {
                 |     Exception e = new Exception();
                 |     Timber.d(e, message);
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -1158,19 +1413,23 @@ class WrongTimberUsageDetectorTest {
                 |     val e = Exception()
                 |     Timber.d(e, message)
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .skipTestModes(TestMode.REORDER_ARGUMENTS)
-        .run()
-        .expectClean()
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .skipTestModes(TestMode.REORDER_ARGUMENTS)
+      .run()
+      .expectClean()
   }
 
-  @Test fun exceptionLoggingUsingFinalField() {
+  @Test
+  fun exceptionLoggingUsingFinalField() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1179,8 +1438,10 @@ class WrongTimberUsageDetectorTest {
                 |     Exception e = new Exception();
                 |     Timber.d(e, message);
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -1189,19 +1450,23 @@ class WrongTimberUsageDetectorTest {
                 |     val e = Exception()
                 |     Timber.d(e, message)
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .skipTestModes(TestMode.REORDER_ARGUMENTS)
-        .run()
-        .expectClean()
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .skipTestModes(TestMode.REORDER_ARGUMENTS)
+      .run()
+      .expectClean()
   }
 
-  @Test fun exceptionLoggingUsingEmptyStringMessage() {
+  @Test
+  fun exceptionLoggingUsingEmptyStringMessage() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1209,8 +1474,10 @@ class WrongTimberUsageDetectorTest {
                 |     Exception e = new Exception();
                 |     Timber.d(e, "");
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -1218,21 +1485,25 @@ class WrongTimberUsageDetectorTest {
                 |     val e = Exception()
                 |     Timber.d(e, "")
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .skipTestModes(TestMode.REORDER_ARGUMENTS, TestMode.WHITESPACE)
-        .run()
-        .expect("""
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .skipTestModes(TestMode.REORDER_ARGUMENTS, TestMode.WHITESPACE)
+      .run()
+      .expect(
+        """
             |src/foo/Example.java:6: Warning: Use single-argument log method instead of null/empty message [TimberExceptionLogging]
             |     Timber.d(e, "");
             |     ~~~~~~~~~~~~~~~
             |src/foo/Example.kt:6: Warning: Use single-argument log method instead of null/empty message [TimberExceptionLogging]
             |     Timber.d(e, "")
             |     ~~~~~~~~~~~~~~~
-            |0 errors, 2 warnings""".trimMargin())
-        .expectFixDiffs("""
+            |0 errors, 2 warnings""".trimMargin()
+      )
+      .expectFixDiffs(
+        """
             |Fix for src/foo/Example.java line 6: Remove redundant argument:
             |@@ -6 +6
             |-      Timber.d(e, "");
@@ -1241,13 +1512,17 @@ class WrongTimberUsageDetectorTest {
             |@@ -6 +6
             |-      Timber.d(e, "")
             |+      Timber.d(e)
-            |""".trimMargin())
+            |""".trimMargin()
+      )
   }
 
-  @Test fun exceptionLoggingUsingNullMessage() {
+  @Test
+  fun exceptionLoggingUsingNullMessage() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1255,8 +1530,10 @@ class WrongTimberUsageDetectorTest {
                 |     Exception e = new Exception();
                 |     Timber.d(e, null);
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -1264,21 +1541,25 @@ class WrongTimberUsageDetectorTest {
                 |     val e = Exception()
                 |     Timber.d(e, null)
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .skipTestModes(TestMode.REORDER_ARGUMENTS, TestMode.WHITESPACE)
-        .run()
-        .expect("""
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .skipTestModes(TestMode.REORDER_ARGUMENTS, TestMode.WHITESPACE)
+      .run()
+      .expect(
+        """
             |src/foo/Example.java:6: Warning: Use single-argument log method instead of null/empty message [TimberExceptionLogging]
             |     Timber.d(e, null);
             |     ~~~~~~~~~~~~~~~~~
             |src/foo/Example.kt:6: Warning: Use single-argument log method instead of null/empty message [TimberExceptionLogging]
             |     Timber.d(e, null)
             |     ~~~~~~~~~~~~~~~~~
-            |0 errors, 2 warnings""".trimMargin())
-        .expectFixDiffs("""
+            |0 errors, 2 warnings""".trimMargin()
+      )
+      .expectFixDiffs(
+        """
             |Fix for src/foo/Example.java line 6: Remove redundant argument:
             |@@ -6 +6
             |-      Timber.d(e, null);
@@ -1287,13 +1568,17 @@ class WrongTimberUsageDetectorTest {
             |@@ -6 +6
             |-      Timber.d(e, null)
             |+      Timber.d(e)
-            |""".trimMargin())
+            |""".trimMargin()
+      )
   }
 
-  @Test fun exceptionLoggingUsingValidMessage() {
+  @Test
+  fun exceptionLoggingUsingValidMessage() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1301,8 +1586,10 @@ class WrongTimberUsageDetectorTest {
                 |     Exception e = new Exception();
                 |     Timber.d(e, "Valid message");
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -1310,90 +1597,110 @@ class WrongTimberUsageDetectorTest {
                 |     val e = Exception()
                 |     Timber.d(e, "Valid message")
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .skipTestModes(TestMode.REORDER_ARGUMENTS)
-        .run()
-        .expectClean()
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .skipTestModes(TestMode.REORDER_ARGUMENTS)
+      .run()
+      .expectClean()
   }
 
-  @Test fun dateFormatNotDisplayingWarning() {
+  @Test
+  fun dateFormatNotDisplayingWarning() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
                 |  public void log() {
                 |    Timber.d("%tc", new java.util.Date());
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
                 |  fun log() {
                 |    Timber.d("%tc", java.util.Date())
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .run()
-        .expectClean()
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .run()
+      .expectClean()
   }
 
-  @Test fun systemTimeMillisValidMessage() {
+  @Test
+  fun systemTimeMillisValidMessage() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
                 |  public void log() {
                 |    Timber.d("%tc", System.currentTimeMillis());
                 |  }
-                |}""".trimMargin()),
-            kotlin("""
+                |}""".trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
                 |  fun log() {
                 |    Timber.d("%tc", System.currentTimeMillis())
                 |  }
-                |}""".trimMargin())
+                |}""".trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .run()
-        .expectClean()
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .run()
+      .expectClean()
   }
 
-  @Test fun wrappedBooleanType() {
+  @Test
+  fun wrappedBooleanType() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
                 |  public void log() {
                 |     Timber.d("%b", Boolean.valueOf(true));
                 |  }
-                |}""".trimMargin()),
-            // no kotlin equivalent, since primitive wrappers do not exist
-        )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .run()
-        .expectClean()
+                |}""".trimMargin()
+        ),
+        // no kotlin equivalent, since primitive wrappers do not exist
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .run()
+      .expectClean()
   }
 
-  @Test fun memberVariable() {
+  @Test
+  fun memberVariable() {
     lint()
-        .files(TIMBER_STUB,
-            java("""
+      .files(
+        TIMBER_STUB,
+        java(
+          """
                 |package foo;
                 |import timber.log.Timber;
                 |public class Example {
@@ -1405,8 +1712,10 @@ class WrongTimberUsageDetectorTest {
                 |    Timber.d(bar.baz);
                 |  }
                 |}
-                """.trimMargin()),
-            kotlin("""
+                """.trimMargin()
+        ),
+        kotlin(
+          """
                 |package foo
                 |import timber.log.Timber
                 |class Example {
@@ -1418,18 +1727,22 @@ class WrongTimberUsageDetectorTest {
                 |    Timber.d(bar.baz)
                 |  }
                 |}
-                """.trimMargin())
+                """.trimMargin()
         )
-        .allowClassNameClashes(true)
-        .issues(*issues)
-        .run()
-        .expectClean()
+      )
+      .allowClassNameClashes(true)
+      .issues(*issues)
+      .run()
+      .expectClean()
   }
 
-    @Test fun exceptionLoggingWithGuardedVariable() {
-        lint()
-            .files(TIMBER_STUB,
-                kotlin("""
+  @Test
+  fun exceptionLoggingWithGuardedVariable() {
+    lint()
+      .files(
+        TIMBER_STUB,
+        kotlin(
+          """
               |package foo
               |import timber.log.Timber
               |import java.lang.Exception
@@ -1451,12 +1764,12 @@ class WrongTimberUsageDetectorTest {
               |     }
               |  }
               |}
-              """.trimMargin())
-            )
-            .issues(WrongTimberUsageDetector.ISSUE_EXCEPTION_LOGGING)
-            .run()
-            // We expect this code to be perfectly clean with NO warnings.
-            .expectClean()
-    }
-
+              """.trimMargin()
+        )
+      )
+      .issues(WrongTimberUsageDetector.ISSUE_EXCEPTION_LOGGING)
+      .run()
+      // We expect this code to be perfectly clean with NO warnings.
+      .expectClean()
+  }
 }


### PR DESCRIPTION
The `TimberExceptionLogging` lint check was incorrectly flagging valid code where a message variable was guarded by an `isNotEmpty()` check.

This was caused by two issues in the detector:
1. The check was not flow-sensitive and couldn't determine that the variable was guaranteed to be non-empty inside the `if` block. It defaulted to flagging any unevaluated variable.
2. The logic for identifying arguments was based on position, causing it to fail when Kotlin's named or reordered arguments were used.

This commit resolves both issues by:
- Making the check more conservative: It now only flags issues it can prove are incorrect (e.g., literal empty strings or redundant `e.getMessage()` calls), avoiding false positives on unevaluated variables.
- Robustly identifying throwable and message arguments by their type, making the check work correctly regardless of argument order.

A new test case has been added to verify the fix and prevent regressions.

Fixes #331