### PR TITLE
Remove explicit JVM toolchain, add Java 8/Kotlin 2.0 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
     classpath libs.gradlePlugin.japicmp
     classpath libs.gradlePlugin.mavenPublish
     classpath libs.gradlePlugin.dokka
+    classpath libs.compatPlugin
   }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ gradlePlugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", ve
 gradlePlugin-dokka = "org.jetbrains.dokka:dokka-gradle-plugin:2.1.0"
 gradlePlugin-japicmp = "me.champeau.gradle:japicmp-gradle-plugin:0.4.6"
 gradlePlugin-mavenPublish = "com.vanniktech:gradle-maven-publish-plugin:0.35.0"
+compatPlugin = "com.gradleup.compat.patrouille:compat-patrouille-gradle-plugin:0.1.0"
 
 annotations = "org.jetbrains:annotations:26.0.2-1"
 auto-service = { module = "com.google.auto.service:auto-service", version.ref = "autoService" }

--- a/timber-lint/build.gradle
+++ b/timber-lint/build.gradle
@@ -1,10 +1,10 @@
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'org.jetbrains.kotlin.kapt'
 apply plugin: 'com.android.lint'
+apply plugin: 'com.gradleup.compat.patrouille'
 
-java {
-  sourceCompatibility = JavaVersion.VERSION_17
-  targetCompatibility = JavaVersion.VERSION_17
+compatPatrouille {
+  java(17)
 }
 
 lint {

--- a/timber-lint/build.gradle
+++ b/timber-lint/build.gradle
@@ -2,6 +2,11 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'org.jetbrains.kotlin.kapt'
 apply plugin: 'com.android.lint'
 
+java {
+  sourceCompatibility = JavaVersion.VERSION_17
+  targetCompatibility = JavaVersion.VERSION_17
+}
+
 lint {
   baseline = file("lint-baseline.xml")
 }

--- a/timber-lint/build.gradle
+++ b/timber-lint/build.gradle
@@ -2,10 +2,6 @@ apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'org.jetbrains.kotlin.kapt'
 apply plugin: 'com.android.lint'
 
-kotlin {
-  jvmToolchain(17)
-}
-
 lint {
   baseline = file("lint-baseline.xml")
 }

--- a/timber/build.gradle
+++ b/timber/build.gradle
@@ -1,7 +1,10 @@
+import compat.patrouille.Severity
+
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'com.android.kotlin.multiplatform.library'
 apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
+apply plugin: 'com.gradleup.compat.patrouille'
 
 kotlin {
   androidLibrary {
@@ -40,9 +43,11 @@ kotlin {
   }
 }
 
-tasks.withType(JavaCompile).configureEach {
-  sourceCompatibility = JavaVersion.VERSION_17
-  targetCompatibility = JavaVersion.VERSION_17
+compatPatrouille {
+  java(8)
+  kotlin('2.0.0')
+  checkApiDependencies(Severity.ERROR)
+  checkRuntimeDependencies(Severity.ERROR)
 }
 
 tasks.named('check') { check ->

--- a/timber/build.gradle
+++ b/timber/build.gradle
@@ -4,49 +4,54 @@ apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
 
 kotlin {
-    androidLibrary {
-        namespace = 'timber.log'
-        compileSdk = libs.versions.compileSdk.get().toInteger()
-        minSdk = libs.versions.minSdk.get().toInteger()
+  androidLibrary {
+    namespace = 'timber.log'
+    compileSdk = libs.versions.compileSdk.get().toInteger()
+    minSdk = libs.versions.minSdk.get().toInteger()
 
-        optimization {
-            // "it" --> https://issuetracker.google.com/issues/445115242
-            it.consumerKeepRules.file('consumer-keep-rules.pro')
-        }
-
-        lint {
-            it.textReport = true
-        }
+    optimization {
+      // "it" --> https://issuetracker.google.com/issues/445115242
+      it.consumerKeepRules.file('consumer-keep-rules.pro')
     }
 
-    sourceSets {
-        commonMain {
-            dependencies {
-                implementation libs.annotations
-            }
-        }
-        commonTest {
-            dependencies {
-                implementation libs.annotations
-                implementation libs.junit
-                implementation libs.assertk
-                implementation libs.robolectric
-            }
-        }
+    lint {
+      it.textReport = true
     }
+  }
 
-    abiValidation {
-        enabled = true
+  sourceSets {
+    commonMain {
+      dependencies {
+        implementation libs.annotations
+      }
     }
+    commonTest {
+      dependencies {
+        implementation libs.annotations
+        implementation libs.junit
+        implementation libs.assertk
+        implementation libs.robolectric
+      }
+    }
+  }
+
+  abiValidation {
+    enabled = true
+  }
+}
+
+tasks.withType(JavaCompile).configureEach {
+  sourceCompatibility = JavaVersion.VERSION_17
+  targetCompatibility = JavaVersion.VERSION_17
 }
 
 tasks.named('check') { check ->
-    check.dependsOn(
-            // TODO: https://youtrack.jetbrains.com/issue/KT-78525
-            tasks.named('checkLegacyAbi'),
-    )
+  check.dependsOn(
+      // TODO: https://youtrack.jetbrains.com/issue/KT-78525
+      tasks.named('checkLegacyAbi'),
+  )
 }
 
 dependencies {
-    lintPublish project(':timber-lint')
+  lintPublish project(':timber-lint')
 }

--- a/timber/build.gradle
+++ b/timber/build.gradle
@@ -4,52 +4,49 @@ apply plugin: 'com.vanniktech.maven.publish'
 apply plugin: 'org.jetbrains.dokka' // Must be applied here for publish plugin.
 
 kotlin {
-  androidLibrary {
-    namespace 'timber.log'
-    compileSdk libs.versions.compileSdk.get().toInteger()
-    minSdk libs.versions.minSdk.get().toInteger()
+    androidLibrary {
+        namespace = 'timber.log'
+        compileSdk = libs.versions.compileSdk.get().toInteger()
+        minSdk = libs.versions.minSdk.get().toInteger()
 
-    optimization {
-      // "it" --> https://issuetracker.google.com/issues/445115242
-      it.consumerKeepRules.file('consumer-keep-rules.pro')
+        optimization {
+            // "it" --> https://issuetracker.google.com/issues/445115242
+            it.consumerKeepRules.file('consumer-keep-rules.pro')
+        }
+
+        lint {
+            it.textReport = true
+        }
     }
 
-    lint {
-      it.textReport = true
+    sourceSets {
+        commonMain {
+            dependencies {
+                implementation libs.annotations
+            }
+        }
+        commonTest {
+            dependencies {
+                implementation libs.annotations
+                implementation libs.junit
+                implementation libs.assertk
+                implementation libs.robolectric
+            }
+        }
     }
-  }
 
-  // TODO Remove!
-  jvmToolchain(17)
-
-  sourceSets {
-    commonMain {
-      dependencies {
-        implementation libs.annotations
-      }
+    abiValidation {
+        enabled = true
     }
-    commonTest {
-      dependencies {
-        implementation libs.annotations
-        implementation libs.junit
-        implementation libs.assertk
-        implementation libs.robolectric
-      }
-    }
-  }
-
-  abiValidation {
-    enabled = true
-  }
 }
 
 tasks.named('check') { check ->
-  check.dependsOn(
-      // TODO: https://youtrack.jetbrains.com/issue/KT-78525
-      tasks.named('checkLegacyAbi'),
-  )
+    check.dependsOn(
+            // TODO: https://youtrack.jetbrains.com/issue/KT-78525
+            tasks.named('checkLegacyAbi'),
+    )
 }
 
 dependencies {
-  lintPublish project(':timber-lint')
+    lintPublish project(':timber-lint')
 }


### PR DESCRIPTION
This commit resolves two build configuration issues:

1. Removes the explicit `jvmToolchain(17)` declarations from the `timber` and `timber-lint` modules. By removing this, we allow the project to be built with the user's configured JDK (or the one used by Gradle), rather than forcing the use of JDK 17. This improves build flexibility for contributors using newer JDKs.

2. Corrects the DSL for setting the Android namespace. The build was failing with a `Could not find method namespace()` error due to using Groovy syntax (`namespace '...'`) with the Kotlin-based KMP Android plugin. This has been updated to the correct Kotlin syntax (`namespace = "..."`).

These changes complete the migration to the modern `com.android.kotlin.multiplatform.library` plugin and make the project easier to build for contributors.

Fixes #545